### PR TITLE
Add review workflow

### DIFF
--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -67,6 +67,11 @@ const trialOptions: Option[] = [
   { value: 'rigid_brace_right_hip', label: 'Brace (Rigid) - Right Hip' },
   { value: 'pneumatic_jets_shoes', label: 'Pneumatic Jets (Shoes)' },
   { value: 'arms_crossed', label: 'Arms Crossed' },
+  // Tags for the review process
+  { value: '_review_new', label: 'Review: Needs review' },
+  { value: '_review_accept', label: 'Review: Accepted' },
+  { value: '_review_reject', label: 'Review: Rejected' },
+  { value: '_review_edit', label: 'Review: Needs editing' },
 ];
 
 const MultiValueLabel = (props: MultiValueGenericProps<Option>) => {


### PR DESCRIPTION
This commit adds the fundamental infra required for reviewing trials, namely tags and keybindings to streamline the review process. By default, all clips without a review tag get tagged with "Needs review" (this ensures backwards compatibility).

To try this out:

1. Open a subject that has finished processing (ideally one with multiple trials).
2. There will be a warning at the top of the page saying that some trials have not been reviewed. Click the review button.
3. The modal dialog will pop up. Use the left and right arrow keys to navigate between trials.
4. Press "a" (accept), "r" (reject), or "e" (needs editing) to review clips.

Todo's

- [ ] Address the todo's in the code
- [ ] Add a colored tag to the modal header with the review status of the current trial
- [ ] (extra credit) Load the nimble viewer for the next trial such that the user does not have to wait for it to load when advancing.