### PR TITLE
Updates for nimblephysics 0.8.80

### DIFF
--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -113,6 +113,16 @@ def processLocalSubjectFolder(path: str, outputName: str = None, href: str = '')
     else:
         tuneResidualLoss = 1.0
 
+    if 'shiftGRFs' in subjectJson:
+        shiftGRFs = subjectJson['shiftGRFs']
+    else:
+        shiftGRFs = False
+
+    if 'maxTrialsToSolveMassOver' in subjectJson:
+        maxTrialsToSolveMassOver = subjectJson['maxTrialsToSolveMassOver']
+    else:
+        maxTrialsToSolveMassOver = 4
+
     if skeletonPreset == 'vicon' or skeletonPreset == 'cmu' or skeletonPreset == 'complete':
         footBodyNames = ['calcn_l', 'calcn_r']
     else:
@@ -427,7 +437,10 @@ def processLocalSubjectFolder(path: str, outputName: str = None, href: str = '')
             dynamicsFitter.boundPush(dynamicsInit)
             dynamicsFitter.smoothAccelerations(dynamicsInit)
             initializeSuccess = dynamicsFitter.timeSyncAndInitializePipeline(
-                dynamicsInit)
+                dynamicsInit,
+                useReactionWheels=useReactionWheels,
+                shiftGRFs=shiftGRFs,
+                maxTrialsToSolveMassOver=maxTrialsToSolveMassOver)
 
             # If initialization succeeded, we will proceed with the kitchen sink optimization.
             # If not, we will re-run timeSyncAndInitializePipeline() with reaction wheels.
@@ -518,7 +531,10 @@ def processLocalSubjectFolder(path: str, outputName: str = None, href: str = '')
                       'body mass optimization and re-running dynamics initialization while allowing large '
                       'residual moments.', flush=True)
                 initializeSuccess = dynamicsFitter.timeSyncAndInitializePipeline(
-                    dynamicsInit, useReactionWheels=True)
+                    dynamicsInit,
+                    useReactionWheels=True,
+                    shiftGRFs=shiftGRFs,
+                    maxTrialsToSolveMassOver=maxTrialsToSolveMassOver)
                 # TODO re-run position only optimization here?
 
             dynamicsFitter.applyInitToSkeleton(finalSkeleton, dynamicsInit)

--- a/server/engine/requirements.txt
+++ b/server/engine/requirements.txt
@@ -1,1 +1,1 @@
-nimblephysics == 0.8.78
+nimblephysics == 0.8.80


### PR DESCRIPTION
This PR includes updates to support `nimblephysics` 0.8.80, including the new flags for setting GRF shifting (`shiftGRFs`) and setting the max number of trials used to solve for model mass during the dynamics fitting step (`maxTrialsToSolveMassOver`).