### PR TITLE
Removed default enter press. Changed input placeholder.

### DIFF
--- a/frontend/src/pages/search/SearchView.tsx
+++ b/frontend/src/pages/search/SearchView.tsx
@@ -138,9 +138,10 @@ const SearchView = observer((props: SearchViewProps) => {
                           <input
                             type="text"
                             className="form-control"
-                            placeholder="Placeholder"
+                            placeholder="Your keywords..."
                             value={searchText}
-                            onChange={function (e) { setSearchText(e.target.value) }}>
+                            onChange={function (e) { setSearchText(e.target.value) }}
+                            onKeyPress={(e) => {e.key === 'Enter' && e.preventDefault();}}>
                           </input>
                         </div>
                       </form>


### PR DESCRIPTION
More information of solved issues in #40:

- In search remove text that says "Placeholder" => Now it shows "Your keywords..." (Should we change it to something else?)
- When you search and hit "return" it doesn't give you your results (looks like the full data) => Removed default behaviour when pressing enter since it automatically updates when you finishes typing.