### PR TITLE
Adding static trial upload in the advanced options tab

### DIFF
--- a/frontend/src/pages/mocap/MocapSubjectView.tsx
+++ b/frontend/src/pages/mocap/MocapSubjectView.tsx
@@ -979,6 +979,24 @@ const MocapSubjectView = observer((props: MocapSubjectViewProps) => {
             props.cursor.setShowValidationControls(e.target.checked);
           }} />
           </div>
+          <div className="mb-15">
+            <label>
+              Static Trial:
+            </label>
+            <OverlayTrigger
+              placement="right"
+              delay={{ show: 50, hide: 400 }}
+              overlay={(props) => (
+                <Tooltip id="button-tooltip" {...props}>
+                  This is a short trial where the model's joints are known to be in the neutral position. If you have uploaded a custom OpenSim file, this is currently assumed to be all joints set to zero.
+                  Using a static trial can be helpful for enforcing tradeoffs between joint angle changes and corresponding marker offsets that can otherwise be somewhat ambiguous, such as pelvis rotation and ankle extension.
+                </Tooltip>
+              )}
+            >
+              <i className="mdi mdi-help-circle-outline text-muted vertical-middle" style={{ marginLeft: '5px' }}></i>
+            </OverlayTrigger>
+            <DropFile cursor={props.cursor} path={"trials/static/markers"} text="Drop a .trc or .c3d file here for your static trial" accept=".trc,.c3d" keepFileExtension={true} />
+          </div>
           <div className="">
             <div className="alert alert-warning" role="alert">
               Experimental - Attempt to Fit Dynamics:{" "}


### PR DESCRIPTION
This addresses https://github.com/keenon/AddBiomechanics/issues/63, by adding UI for setting a static trial under the "Advanced" tab. We don't yet have a way to set the neutral pose for your skeleton, or set markers to ignore, but it's a start.