### PR TITLE
WIP - Fix upload progressBar

### DIFF
--- a/frontend/src/components/DropFile.tsx
+++ b/frontend/src/components/DropFile.tsx
@@ -102,9 +102,9 @@ const DropFile = observer((props: DropFileProps) => {
                 pathToUpload = pathToUpload.split(".")[0] + extension;
               }
               props.cursor.rawCursor.uploadChild(pathToUpload, acceptedFiles[0], setUploadProgress).then(action(() => {
-                setIsUploading(false);
+                
               })).catch(action(() => {
-                setIsUploading(false);
+                
               }));
             }
           });

--- a/frontend/src/pages/mocap/MocapSubjectView.tsx
+++ b/frontend/src/pages/mocap/MocapSubjectView.tsx
@@ -722,7 +722,7 @@ const MocapSubjectView = observer((props: MocapSubjectViewProps) => {
           </li>);
         }
       }
-      warningList.push(<li key={"fewFrames"}>
+      warningList.push(<li key={"jointLimits"}>
         <p>The OpenSim skeleton hit its joint limits during the trial. This may lead to poor/jittery IK results. Here are joints to investigate:</p>
         <ul>
           {warningsBlocks}

--- a/frontend/src/state/ReactiveS3.ts
+++ b/frontend/src/state/ReactiveS3.ts
@@ -976,9 +976,9 @@ class ReactiveIndex {
         };
         const topic = makeTopicPubSubSafe("/UPDATE/" + fullPath);
         console.log("Updating '" + topic + "' with " + JSON.stringify(updatedFile));
-        return this.s3client.then((client) => {
+        return this.s3client.then(async (client) => {
             const uploadObject = new RobustUpload(client, this.region, this.bucketName, fullPath, contents, '');
-            uploadObject.upload((progress) => {
+            await uploadObject.upload((progress) => {
                 progressCallback(progress.loaded / progress.total);
             }).then((response: any) => {
                 console.log("S3.put() Completed callback", response);


### PR DESCRIPTION
The changes I implemented are working only on one case.

- Click create new trial
- Create a trial with any name
- Drop a file in the red drop area

What I did basically is to make the call to RobustUpload async, and wait until it finishes. This way, it is not returning before the upload finishes. Then I removed the setIsUploading(false) call in onDrop for testing another hting, and for some reason, it works (I don't know why after removing it the progressBar dissapears, since the state should not be changing. I will try removing the cache of the browser just in case).

**Note: The change to a key in MocapSubjectView.tsx is unrelated, the key was repeated and I change its name.**