### PR TITLE
Added user's inserted title to dataset view and search results. Added dataset description to search results.

### DIFF
--- a/frontend/src/pages/files/FileControlsWrapper.tsx
+++ b/frontend/src/pages/files/FileControlsWrapper.tsx
@@ -304,6 +304,16 @@ const FileManager = observer((props: FileManagerProps) => {
                   <>
                       {(() => {
                         let sidebarContent = []
+
+                        if (props.cursor.searchJson.getAttribute("title", "") !== "") {
+                          sidebarContent.push (
+                            <li key="title">
+                              <br></br>
+                              <h2 style={{ width: '100%' }}>{props.cursor.searchJson.getAttribute("title", "")}</h2>
+                            </li>
+                          )
+                        }
+
                         if (props.cursor.searchJson.getAttribute("notes", "") !== "") {
                           sidebarContent.push (
                             <li key="notes">

--- a/frontend/src/state/MocapS3Cursor.ts
+++ b/frontend/src/state/MocapS3Cursor.ts
@@ -79,7 +79,6 @@ type Dataset = {
     isHomeFolder: boolean
     isPublished: boolean;
     hasDynamics: boolean;
-    description: string | undefined;
 };
 
 class MocapDatasetIndex {
@@ -174,8 +173,7 @@ class MocapDatasetIndex {
                         numTrials: 0,
                         isPublished: false,
                         hasDynamics: hasPhysics,
-                        isHomeFolder: i == 2,
-                        description: undefined
+                        isHomeFolder: i == 2
                     };
                     datasetMap.set(key, dataset);
                 }
@@ -214,8 +212,7 @@ class MocapDatasetIndex {
                         numSubjects: 0,
                         numTrials: 0,
                         isPublished: true,
-                        hasDynamics: false,
-                        description: undefined
+                        hasDynamics: false
                     };
                     datasetMap.set(filteredKey, dataset);
                 }
@@ -271,9 +268,7 @@ class MocapDatasetIndex {
 
                 return false;
             }
-            else {
-                return true;
-            }
+            return true;
         });
     };
 }

--- a/frontend/src/state/MocapS3Cursor.ts
+++ b/frontend/src/state/MocapS3Cursor.ts
@@ -79,6 +79,7 @@ type Dataset = {
     isHomeFolder: boolean
     isPublished: boolean;
     hasDynamics: boolean;
+    description: string | undefined;
 };
 
 class MocapDatasetIndex {
@@ -173,7 +174,8 @@ class MocapDatasetIndex {
                         numTrials: 0,
                         isPublished: false,
                         hasDynamics: hasPhysics,
-                        isHomeFolder: i == 2
+                        isHomeFolder: i == 2,
+                        description: undefined
                     };
                     datasetMap.set(key, dataset);
                 }
@@ -212,7 +214,8 @@ class MocapDatasetIndex {
                         numSubjects: 0,
                         numTrials: 0,
                         isPublished: true,
-                        hasDynamics: false
+                        hasDynamics: false,
+                        description: undefined
                     };
                     datasetMap.set(filteredKey, dataset);
                 }
@@ -268,7 +271,9 @@ class MocapDatasetIndex {
 
                 return false;
             }
-            return true;
+            else {
+                return true;
+            }
         });
     };
 }


### PR DESCRIPTION
User's inserted title for a dataset was not visible anywhere, so I added it to other person's public datasets (if exists). It is also shown in the search results.

Regarding description in search results, there was a little bug causing it to not be shown (the function that filters the urls expect it to not to have a "/" at the end, and in this case, it was having it).

**Note:** Right now, we are only searching by folder's name, but it would be interesting allowing searching in the description and user's inserted title too. However, I think this would imply loading all `_search.json` files beforehand. Also, we cannot search "Home Folder" datasets, since the folder name is empty string ("").