### PR TITLE
Added missing else case to 3d visualizer

### DIFF
--- a/frontend/src/pages/mocap/MocapTrialModal.tsx
+++ b/frontend/src/pages/mocap/MocapTrialModal.tsx
@@ -309,7 +309,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
             for (let j = 0; j < plotTags.length; j++) {
                 let label = plotTags[j];
                 if (label.indexOf("tau") !== -1) {
-                    if (scales['Nm'] == null) {
+                    if (!scales.hasOwnProperty("Nm")) {
                         scales['Nm'] = {
                             type: 'linear',
                             display: true,
@@ -324,7 +324,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                     }
                 }
                 else if (label.indexOf("force") !== -1) {
-                    if (scales['N'] == null) {
+                    if (!scales.hasOwnProperty("N")) {
                         scales['N'] = {
                             type: 'linear',
                             display: true,
@@ -339,7 +339,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                     }
                 }
                 else if (label.indexOf("pos") !== -1) {
-                    if (scales['units'] == null) {
+                    if (!scales.hasOwnProperty("units")) {
                         scales['units'] = {
                             type: 'linear',
                             display: true,
@@ -354,7 +354,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                     }
                 }
                 else if (label.indexOf("vel") !== -1) {
-                    if (scales['units/s'] == null) {
+                    if (!scales.hasOwnProperty("units/s")) {
                         scales['units/s'] = {
                             type: 'linear',
                             display: true,
@@ -369,7 +369,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                     }
                 }
                 else if (label.indexOf("acc") !== -1) {
-                    if (scales['units/s^2'] == null) {
+                    if (!scales.hasOwnProperty("units/s^2")) {
                         scales['units/s^2'] = {
                             type: 'linear',
                             display: true,
@@ -383,7 +383,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                         };
                     }
                 } else {
-                    if (scales[""] == null) {
+                    if (!scales.hasOwnProperty("")) {
                         scales[""] = {
                             type: 'linear',
                             display: true,

--- a/frontend/src/pages/mocap/MocapTrialModal.tsx
+++ b/frontend/src/pages/mocap/MocapTrialModal.tsx
@@ -382,6 +382,20 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                             }
                         };
                     }
+                } else {
+                    if (scales[""] == null) {
+                        scales[""] = {
+                            type: 'linear',
+                            display: true,
+                            position: 'left',
+                            ticks: {
+                                beginAtZero: true,
+                                callback: function (value: any, index: any, values: any) {
+                                    return value + ' ""';
+                                }
+                            }
+                        };
+                    }
                 }
             }
 
@@ -397,7 +411,7 @@ const MocapTrialModal = observer((props: MocapTrialModalProps) => {
                         data.push(plotCSV[i].get(label) as number);
                     }
                 }
-                let yAxisID = '';
+                let yAxisID = "";
                 if (label.indexOf("tau") !== -1) {
                     yAxisID = "Nm";
                 }


### PR DESCRIPTION
When the scales definitions are created, there was no final else case, so a scale was not created for elements that don't meet the criteria of the rest of the cases.