### PR TITLE
Support for error reporting in `engine.py`

### DIFF
--- a/server/app/mocap_server.py
+++ b/server/app/mocap_server.py
@@ -121,6 +121,7 @@ class SubjectToProcess:
     readyFlagFile: str
     processingFlagFile: str
     resultsFile: str
+    errorsFile: str
     logfile: str
 
     # Trial objects
@@ -153,6 +154,7 @@ class SubjectToProcess:
         self.processingFlagFile = self.subjectPath + 'PROCESSING'
         self.errorFlagFile = self.subjectPath + 'ERROR'
         self.resultsFile = self.subjectPath + '_results.json'
+        self.errorsFile = self.subjectPath + '_errors.json'
         self.osimResults = self.subjectPath + self.subjectName + '.zip'
         self.pytorchResults = self.subjectPath + self.subjectName + '.bin'
         self.logfile = self.subjectPath + 'log.txt'
@@ -352,6 +354,15 @@ class SubjectToProcess:
                 if os.path.exists(path + self.subjectName + '.bin'):
                     self.index.uploadFile(
                         self.pytorchResults, path + self.subjectName + '.bin')
+
+                # 5.1.3. Upload the _errors.json file.
+                if os.path.exists(path + '_errors.json'):
+                    self.index.uploadFile(
+                        self.errorsFile, path + '_errors.json')
+                else:
+                    print('WARNING! FILE NOT UPLOADED BECAUSE FILE NOT FOUND! ' +
+                          path + '_errors.json', flush=True)
+
                 # 5.2. Upload the _results.json file last, since that marks the trial as DONE on the frontend,
                 # and it starts to be able
                 if os.path.exists(path + '_results.json'):

--- a/server/app/mocap_server.py
+++ b/server/app/mocap_server.py
@@ -359,9 +359,6 @@ class SubjectToProcess:
                 if os.path.exists(path + '_errors.json'):
                     self.index.uploadFile(
                         self.errorsFile, path + '_errors.json')
-                else:
-                    print('WARNING! FILE NOT UPLOADED BECAUSE FILE NOT FOUND! ' +
-                          path + '_errors.json', flush=True)
 
                 # 5.2. Upload the _results.json file last, since that marks the trial as DONE on the frontend,
                 # and it starts to be able

--- a/server/engine/.gitignore
+++ b/server/engine/.gitignore
@@ -1,0 +1,1 @@
+/testing

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -21,14 +21,15 @@ import traceback
 from plotting import plot_ik_results, plot_id_results, plot_marker_errors, plot_grf_data
 from helpers import detect_nonzero_force_segments, filter_nonzero_force_segments, get_consecutive_values, \
                     reconcile_markered_and_nonzero_force_segments, detect_markered_segments
-from exceptions import PathError
+from exceptions import Error, PathError, SubjectConfigurationError, ModelFileError, TrialPreprocessingError, \
+                       MarkerFitterError, DynamicsFitterError, WriteError
 
 # Global paths to the geometry and data folders.
 GEOMETRY_FOLDER_PATH = absPath('Geometry')
 DATA_FOLDER_PATH = absPath('../data')
 
 
-# This metaclass wraps all methods in the Engine class with a try/except block, except for the __init__ method.
+# This metaclass wraps all methods in the Engine class with a try-except block, except for the __init__ method.
 class ExceptionHandlingMeta(type):
     def __new__(cls, name, bases, attrs):
         for attr_name, attr_value in attrs.items():
@@ -45,8 +46,26 @@ class ExceptionHandlingMeta(type):
                 method(*args, **kwargs)
             except Exception as e:
                 msg = f"Exception caught in {method.__name__}: {e}"
-                if method.__name__ is 'validate_paths':
+                if method.__name__ == 'validate_paths':
                     raise PathError(msg)
+                elif method.__name__ == 'parse_subject_json':
+                    raise SubjectConfigurationError(msg)
+                elif method.__name__ == 'load_model_files':
+                    raise ModelFileError(msg)
+                elif method.__name__ == 'configure_marker_fitter':
+                    raise MarkerFitterError(msg)
+                elif method.__name__ == 'segment_trials':
+                    raise TrialPreprocessingError(msg)
+                elif method.__name__ == 'run_marker_fitting':
+                    raise MarkerFitterError(msg)
+                elif method.__name__ == 'run_dynamics_fitting':
+                    raise DynamicsFitterError(msg)
+                elif method.__name__ == 'write_result_files':
+                    raise WriteError(msg)
+                elif method.__name__ == 'generate_readme':
+                    raise WriteError(msg)
+                elif method.__name__ == 'create_output_folder':
+                    raise WriteError(msg)
 
         return wrapper
 
@@ -141,7 +160,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
         # ---------------------------------
         # 1.1. Check that the Geometry folder exists.
         if not os.path.exists(GEOMETRY_FOLDER_PATH):
-            raise Exception('Geometry folder "' + GEOMETRY_FOLDER_PATH + '" does not exist. Quitting...')
+            raise IsADirectoryError('Geometry folder "' + GEOMETRY_FOLDER_PATH + '" does not exist.')
 
         # 1.2. Symlink in Geometry, if it doesn't come with the folder, so we can load meshes for the visualizer.
         if not os.path.exists(self.geometry_symlink_path):
@@ -149,11 +168,11 @@ class Engine(metaclass=ExceptionHandlingMeta):
 
         # 1.3. Get the subject JSON file path.
         if not os.path.exists(self.subject_json_path):
-            raise Exception('Subject JSON file "' + self.subject_json_path + '" does not exist. Quitting...')
+            raise FileNotFoundError('Subject JSON file "' + self.subject_json_path + '" does not exist.')
 
         # 1.4. Check that the trials folder exists.
         if not os.path.exists(self.trialsFolderPath):
-            raise Exception('Trials folder "' + self.trialsFolderPath + '" does not exist. Quitting...')
+            raise IsADirectoryError('Trials folder "' + self.trialsFolderPath + '" does not exist.')
 
     def parse_subject_json(self):
 
@@ -165,24 +184,22 @@ class Engine(metaclass=ExceptionHandlingMeta):
         if 'massKg' in subjectJson:
             self.massKg = float(subjectJson['massKg'])
         else:
-            print('ERROR: No mass specified for subject. Exiting...')
-            exit(1)
+            raise RuntimeError('No mass specified for subject.')
 
         if 'heightM' in subjectJson:
             self.heightM = float(subjectJson['heightM'])
         else:
-            print('ERROR: No height specified for subject. Exiting...')
-            exit(1)
+            raise RuntimeError('No height specified for subject.')
 
         if 'sex' in subjectJson:
             self.sex = subjectJson['sex']
         else:
-            print('WARNING: No sex specified for subject. Defaulting to "unknown".')
+            raise RuntimeError('No sex specified for subject.')
 
         if 'skeletonPreset' in subjectJson:
             self.skeletonPreset = subjectJson['skeletonPreset']
         else:
-            print('WARNING: No skeletonPreset specified for subject. Defaulting to "custom".')
+            raise RuntimeError('No skeletonPreset specified for subject.')
 
         if 'exportSDF' in subjectJson:
             self.exportSDF = subjectJson['exportSDF']
@@ -265,8 +282,8 @@ class Engine(metaclass=ExceptionHandlingMeta):
                 print('Unrecognized skeleton preset "' + str(self.skeletonPreset) +
                       '"! Behaving as though this is "custom"')
             if not os.path.exists(self.path + 'unscaled_generic.osim'):
-                raise Exception('We are using a custom OpenSim skeleton, but there is no unscaled_generic.osim '
-                                'file present. Quitting...')
+                raise FileNotFoundError('We are using a custom OpenSim skeleton, but there is no unscaled_generic.osim '
+                                        'file present.')
 
         # 3.1. Rationalize CustomJoint's in the OSIM file.
         shutil.move(self.path + 'unscaled_generic.osim',
@@ -339,10 +356,10 @@ class Engine(metaclass=ExceptionHandlingMeta):
         self.markerFitter.setMinAxisFitScore(0.001)
         self.markerFitter.setMaxJointWeight(1.0)
 
-    def segment_trials(self):
+    def preprocess_trials(self):
 
-        # 6. Segment the trials.
-        # ----------------------
+        # 6. Preprocess the trials.
+        # -------------------------
         # 6.1. Get the static trial, if it exists.
         for trialName in os.listdir(self.trialsFolderPath):
             if trialName == 'static':
@@ -425,7 +442,8 @@ class Engine(metaclass=ExceptionHandlingMeta):
             else:
                 print('ERROR: No marker files exist for trial ' + trialName + '. Checked both ' +
                       c3dFilePath + ' and ' + trcFilePath + ', neither exist. Quitting.')
-                exit(1)
+                raise RuntimeError(f'No marker files exist for trial {trialName}. '
+                                   f'Checked both {c3dFilePath} and {trcFilePath}, but neither exist.')
 
             self.trialProcessingResults.append(trialProcessingResult)
 
@@ -457,8 +475,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
 
                 # Check that the marker and force data have the same length.
                 if len(self.trialTimestamps[itrial]) != len(self.trialForcePlates[itrial][0].timestamps):
-                    raise Exception(
-                        'ERROR: Marker and force plate data have different lengths after trimming. Quitting...')
+                    raise RuntimeError('Marker and force plate data have different lengths after trimming.')
 
             # 6.2.3. Split the trial into individual segments where there is marker data and, if applicable, non-zero
             # forces.
@@ -637,8 +654,8 @@ class Engine(metaclass=ExceptionHandlingMeta):
                       str(self.trialMarkerSet[self.trialNames[i]]), flush=True)
                 anyHasTooFewMarkers = True
         if anyHasTooFewMarkers:
-            print("Some trials don't match the OpenSim model's marker set. Quitting.", flush=True)
-            exit(1)
+            raise RuntimeError('Some trials do not match the OpenSim model\'s marker set.')
+
         print('All trial markers have been cleaned up!', flush=True)
 
         # 7.2. Create an anthropometric prior.
@@ -734,8 +751,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
         for name in self.footBodyNames:
             foot = self.finalSkeleton.getBodyNode(name)
             if foot is None:
-                raise Exception(f'ERROR: foot "{str(name)}" not found in skeleton! Dynamics fitter will break as a '
-                                f'result.')
+                raise RuntimeError(f'Foot "{str(name)}" not found in skeleton! Cannot run dynamics fitting.')
             footBodies.append(self.finalSkeleton.getBodyNode(name))
 
         self.finalSkeleton.setGravity([0, -9.81, 0])
@@ -2017,7 +2033,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
         try:
             with open(self.path + '_results.json', 'w') as f:
                 json.dump(self.processingResult, f)
-        except Exception as e:
+        except RuntimeError as e:
             print('Had an error writing _results.json:', flush=True)
             print(e, flush=True)
 
@@ -2031,8 +2047,7 @@ def main():
     # ------------------------
     print(sys.argv, flush=True)
     if len(sys.argv) < 2:
-        print('ERROR: Must provide a path to a subject folder. Exiting...')
-        exit(1)
+        raise RuntimeError('Must provide a path to a subject folder.')
 
     # Subject folder path.
     path = sys.argv[1]
@@ -2053,17 +2068,30 @@ def main():
 
     # Run the pipeline.
     # -----------------
-    engine.validate_paths()
-    engine.parse_subject_json()
-    engine.load_model_files()
-    engine.configure_marker_fitter()
-    engine.segment_trials()
-    engine.run_marker_fitting()
-    if engine.fitDynamics:
-        engine.run_dynamics_fitting()
-    engine.write_result_files()
-    engine.generate_readme()
-    engine.create_output_folder()
+    try:
+        # Each method is automatically wrapped in a try-catch block so
+        # that the pipeline will continue running if an error occurs.
+        engine.validate_paths()
+        engine.parse_subject_json()
+        engine.load_model_files()
+        engine.configure_marker_fitter()
+        engine.preprocess_trials()
+        engine.run_marker_fitting()
+        if engine.fitDynamics:
+            engine.run_dynamics_fitting()
+        engine.write_result_files()
+        engine.generate_readme()
+        engine.create_output_folder()
+
+        # If we succeeded, write an empty JSON file.
+        with open(engine.errors_json_path, "w") as json_file:
+            json_file.write("{}")
+
+    except Error as e:
+        # If we failed, write a JSON file with the error information.
+        json_data = json.dumps(e.get_error_dict(), indent=4)
+        with open(engine.errors_json_path, "w") as json_file:
+            json_file.write(json_data)
 
 
 if __name__ == "__main__":

--- a/server/engine/exceptions.py
+++ b/server/engine/exceptions.py
@@ -38,7 +38,7 @@ class PathError(Error):
     """Raised when a input data path is invalid."""
     def get_message(self):
         return "PathError: Error encountered when detecting the Geometry folder, subject JSON file, and trials " \
-               "directory. These files and/or folder may be missing or invalid."
+               "directory. These files and/or folders may be missing or invalid."
 
 
 class SubjectConfigurationError(Error):

--- a/server/engine/exceptions.py
+++ b/server/engine/exceptions.py
@@ -1,17 +1,99 @@
+"""
+exceptions.py
+-------------
+Description: Custom exception classes for use in the AddBiomechanics processing engine.
+Author(s): Nicholas Bianco
+"""
+
+import textwrap
+
+
 class Error(Exception):
     """Base class for exceptions used in the AddBiomechanics engine."""
-    def __init__(self, previous_message):
-        self.previous_message = previous_message
-        self.message = f"{self.get_message()} {self.previous_message}"
+    def __init__(self, original_message):
+        self.message = f'{self.get_message()} Below is the original error message, which main contain useful ' \
+                       f'information about your issue. If you are unable to resolve the issue, please submit a ' \
+                       f'forum post at https://simtk.org/projects/addbiomechanics or a submit a GitHub Issue at ' \
+                       f'https://github.com/keenon/AddBiomechanics/issues with all error messages included.'
+        self.original_message = f'\n\n{textwrap.indent(original_message, " " * 4)}\n\n'
+        self.type = self.get_type()
 
         super().__init__(self.message)
 
     def get_message(self):
         raise NotImplementedError("Subclasses must implement the 'get_message' method.")
 
+    def get_type(self):
+        return self.__class__.__name__
+
+    def get_error_dict(self):
+        return {
+            "type": self.type,
+            "message": self.message,
+            "original_message": self.original_message
+        }
+
 
 class PathError(Error):
-    """Raised when a path is invalid."""
+    """Raised when a input data path is invalid."""
     def get_message(self):
-        return "DerivedException: This is a custom message."
+        return "PathError: Error encountered when detecting the Geometry folder, subject JSON file, and trials " \
+               "directory. These files and/or folder may be missing or invalid."
 
+
+class SubjectConfigurationError(Error):
+    """Raised when a the provided subject information is missing or malformed.."""
+    def get_message(self):
+        return "SubjectConfigurationError: Error encountered when reading in subject-specific information. Please " \
+               "check that the height, weight, sex, and model file for the subject are all provided and correct."
+
+
+class ModelFileError(Error):
+    """Raised when the provided model file is missing or malformed."""
+    def get_message(self):
+        return "ModelFileError: Error encountered when loading preset or custom model file(s). Please check that you " \
+               "have provided a valid OpenSim Model file and that the file is not corrupted (e.g., by trying to load " \
+               "it into the OpenSim GUI). If you are using a model with a custom markerset, please check that the " \
+               "markers are attached to the correct bodies and correspond to the experimental marker trajectories " \
+               "you have provided."
+
+
+class TrialPreprocessingError(Error):
+    """Raised when an error occurs during the trial segmentation step."""
+    def get_message(self):
+        return "TrialPreprocessingError: Error encountered when preprocessing the marker and/or ground " \
+               "reaction force data. Please check that your data files do not contain any NaN or other invalid " \
+               "values. It is also recommend to check that certainty quantities have zero or non-zero value when " \
+               "you expect them to be zero or non-zero, respectively. If you have provided both marker and ground " \
+               "reaction force data, please check that the number of frames in each file is the same and that the " \
+               "time stamps are consistent. If you have enabled automatic trial segmentation, try disabling this " \
+               "option and manually trimming the data for each trial."
+
+
+class MarkerFitterError(Error):
+    """Raised when an error occurs during the marker fitting step."""
+    def get_message(self):
+        return "MarkerFitterError: Error encountered when running the marker fitting step. This step is highly " \
+               "dependent on the quality of the marker data provided. Please check that the marker trajectories are " \
+               "smooth and do not contain any large gaps or other artifacts (e.g., due to filtering). Check that " \
+               "markers are labeled correctly and that the marker set is consistent across trials. Try visualizing " \
+               "the marker trajectories in the OpenSim GUI to check for any obvious issues (e.g., markers swapping " \
+               "segments at different frames)."
+
+
+class DynamicsFitterError(Error):
+    """Raised when an error occurs during the dynamics fitting step."""
+    def get_message(self):
+        return "DynamicsFitterError: Error encountered when running the dynamics fitting step. This step is highly " \
+               "dependent on the quality of the ground reaction force data provided and its consistency with the " \
+               "marker data. Please check that the ground reaction force data is smooth and does not contain any " \
+               "unexpected large gaps or other artifacts (e.g., due to filtering). Check that the force labels are " \
+               "are consistent with the standard for OpenSim ExternalLoads files. Try visualizing the ground " \
+               "reaction force data in the OpenSim GUI to check for any obvious issues (e.g., forces switching " \
+               "between feet or not aligning with the feet at all)."
+
+
+class WriteError(Error):
+    """Raised when an error occurs when writing out the results."""
+    def get_message(self):
+        return "WriteResultsError: Error encountered when writing out the result files."

--- a/server/engine/exceptions.py
+++ b/server/engine/exceptions.py
@@ -1,0 +1,17 @@
+class Error(Exception):
+    """Base class for exceptions used in the AddBiomechanics engine."""
+    def __init__(self, previous_message):
+        self.previous_message = previous_message
+        self.message = f"{self.get_message()} {self.previous_message}"
+
+        super().__init__(self.message)
+
+    def get_message(self):
+        raise NotImplementedError("Subclasses must implement the 'get_message' method.")
+
+
+class PathError(Error):
+    """Raised when a path is invalid."""
+    def get_message(self):
+        return "DerivedException: This is a custom message."
+

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -15,104 +15,105 @@ from engine import Engine
 import shutil
 import json
 from helpers import detect_nonzero_force_segments, filter_nonzero_force_segments, \
-    reconcile_markered_and_nonzero_force_segments
+                    reconcile_markered_and_nonzero_force_segments
+from exceptions import Error
 
 DATA_FOLDER_PATH = absPath('../data')
 GEOMETRY_FOLDER_PATH = absPath('Geometry')
 
 
-class TestTrialSegmentation(unittest.TestCase):
-    def test_detectNonZeroForceSegments(self):
-        # Create force plate data with intermittent loads.
-        timestamps = np.linspace(0, 6.0, 601)
-        totalLoad = np.zeros(len(timestamps))
-
-        # Add a legitimate load segment.
-        totalLoad[50:100] = 1.0
-        # Add a load segment that is too short.
-        totalLoad[250:254] = 1.0
-        # Add two load segments that should be merged together.
-        totalLoad[300:340] = 1.0
-        totalLoad[360:400] = 1.0
-        # Add a segment that has load up until the final time point.
-        totalLoad[550:601] = 1.0
-
-        # Detect the non-zero force segments.
-        nonzeroForceSegments = detect_nonzero_force_segments(timestamps, totalLoad)
-
-        # Check that the correct segments were detected, before filtering.
-        self.assertEqual(len(nonzeroForceSegments), 5)
-        self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
-        self.assertEqual(nonzeroForceSegments[1][0], 2.5)
-        self.assertAlmostEqual(nonzeroForceSegments[1][1], 2.54, places=5)
-        self.assertEqual(nonzeroForceSegments[2], (3.0, 3.4))
-        self.assertEqual(nonzeroForceSegments[3], (3.6, 4.0))
-        self.assertEqual(nonzeroForceSegments[4], (5.5, 6.0))
-
-        # Now filter the segments.
-        nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
-
-        # Check that the correct segments were detected, after filtering.
-        self.assertEqual(len(nonzeroForceSegments), 3)
-        self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
-        self.assertEqual(nonzeroForceSegments[1], (3.0, 4.0))
-        self.assertEqual(nonzeroForceSegments[2], (5.5, 6.0))
-
-    def test_Camargo2021(self):
-        # Load the data.
-        trcFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01.trc'
-        grfFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01_grf.mot'
-        trcFile: nimble.biomechanics.OpenSimTRC = nimble.biomechanics.OpenSimParser.loadTRC(trcFilePath)
-        forcePlates: List[nimble.biomechanics.ForcePlate] = nimble.biomechanics.OpenSimParser.loadGRF(
-            grfFilePath, trcFile.framesPerSecond)
-
-        # Compute the total load.
-        totalLoad = np.zeros(len(forcePlates[0].timestamps))
-        for itime in range(len(totalLoad)):
-            totalForce = 0
-            totalMoment = 0
-            for forcePlate in forcePlates:
-                totalForce += np.linalg.norm(forcePlate.forces[itime])
-                totalMoment += np.linalg.norm(forcePlate.moments[itime])
-            totalLoad[itime] = totalForce + totalMoment
-
-        # Detect the non-zero force segments.
-        nonzeroForceSegments = detect_nonzero_force_segments(forcePlates[0].timestamps, totalLoad)
-
-        # Filter the segments.
-        nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
-
-        # Check that the correct segments were detected.
-        self.assertEqual(len(nonzeroForceSegments), 3)
-        self.assertEqual(nonzeroForceSegments[0], (0.005, 5.92))
-        self.assertEqual(nonzeroForceSegments[1], (7.365, 8.455))
-        self.assertEqual(nonzeroForceSegments[2], (11.895, 15.335))
-
-    def test_reconcileMarkeredAndNonzeroForceSegments(self):
-        # Create force plate data with intermittent loads.
-        timestamps = np.linspace(0, 10.0, 1001)
-
-        # Create marker segments
-        markerSegments = list()
-        markerSegments.append(timestamps[0:200])
-        markerSegments.append(timestamps[500:600])
-        markerSegments.append(timestamps[800:1000])
-
-        # Create force segments
-        forceSegments = list()
-        forceSegments.append(timestamps[100:300])
-        forceSegments.append(timestamps[350:400])
-        forceSegments.append(timestamps[550:600])
-        forceSegments.append(timestamps[700:950])
-
-        # Reconcile the segments.
-        finalSegments = reconcile_markered_and_nonzero_force_segments(timestamps, markerSegments, forceSegments)
-
-        # Check that the correct segments were detected.
-        self.assertEqual(len(finalSegments), 3)
-        self.assertEqual(finalSegments[0], (1.0, 2.0))
-        self.assertEqual(finalSegments[1], (5.5, 6.0))
-        self.assertEqual(finalSegments[2], (8.0, 9.5))
+# class TestTrialSegmentation(unittest.TestCase):
+#     def test_detectNonZeroForceSegments(self):
+#         # Create force plate data with intermittent loads.
+#         timestamps = np.linspace(0, 6.0, 601)
+#         totalLoad = np.zeros(len(timestamps))
+#
+#         # Add a legitimate load segment.
+#         totalLoad[50:100] = 1.0
+#         # Add a load segment that is too short.
+#         totalLoad[250:254] = 1.0
+#         # Add two load segments that should be merged together.
+#         totalLoad[300:340] = 1.0
+#         totalLoad[360:400] = 1.0
+#         # Add a segment that has load up until the final time point.
+#         totalLoad[550:601] = 1.0
+#
+#         # Detect the non-zero force segments.
+#         nonzeroForceSegments = detect_nonzero_force_segments(timestamps, totalLoad)
+#
+#         # Check that the correct segments were detected, before filtering.
+#         self.assertEqual(len(nonzeroForceSegments), 5)
+#         self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
+#         self.assertEqual(nonzeroForceSegments[1][0], 2.5)
+#         self.assertAlmostEqual(nonzeroForceSegments[1][1], 2.54, places=5)
+#         self.assertEqual(nonzeroForceSegments[2], (3.0, 3.4))
+#         self.assertEqual(nonzeroForceSegments[3], (3.6, 4.0))
+#         self.assertEqual(nonzeroForceSegments[4], (5.5, 6.0))
+#
+#         # Now filter the segments.
+#         nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
+#
+#         # Check that the correct segments were detected, after filtering.
+#         self.assertEqual(len(nonzeroForceSegments), 3)
+#         self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
+#         self.assertEqual(nonzeroForceSegments[1], (3.0, 4.0))
+#         self.assertEqual(nonzeroForceSegments[2], (5.5, 6.0))
+#
+#     def test_Camargo2021(self):
+#         # Load the data.
+#         trcFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01.trc'
+#         grfFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01_grf.mot'
+#         trcFile: nimble.biomechanics.OpenSimTRC = nimble.biomechanics.OpenSimParser.loadTRC(trcFilePath)
+#         forcePlates: List[nimble.biomechanics.ForcePlate] = nimble.biomechanics.OpenSimParser.loadGRF(
+#             grfFilePath, trcFile.framesPerSecond)
+#
+#         # Compute the total load.
+#         totalLoad = np.zeros(len(forcePlates[0].timestamps))
+#         for itime in range(len(totalLoad)):
+#             totalForce = 0
+#             totalMoment = 0
+#             for forcePlate in forcePlates:
+#                 totalForce += np.linalg.norm(forcePlate.forces[itime])
+#                 totalMoment += np.linalg.norm(forcePlate.moments[itime])
+#             totalLoad[itime] = totalForce + totalMoment
+#
+#         # Detect the non-zero force segments.
+#         nonzeroForceSegments = detect_nonzero_force_segments(forcePlates[0].timestamps, totalLoad)
+#
+#         # Filter the segments.
+#         nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
+#
+#         # Check that the correct segments were detected.
+#         self.assertEqual(len(nonzeroForceSegments), 3)
+#         self.assertEqual(nonzeroForceSegments[0], (0.005, 5.92))
+#         self.assertEqual(nonzeroForceSegments[1], (7.365, 8.455))
+#         self.assertEqual(nonzeroForceSegments[2], (11.895, 15.335))
+#
+#     def test_reconcileMarkeredAndNonzeroForceSegments(self):
+#         # Create force plate data with intermittent loads.
+#         timestamps = np.linspace(0, 10.0, 1001)
+#
+#         # Create marker segments
+#         markerSegments = list()
+#         markerSegments.append(timestamps[0:200])
+#         markerSegments.append(timestamps[500:600])
+#         markerSegments.append(timestamps[800:1000])
+#
+#         # Create force segments
+#         forceSegments = list()
+#         forceSegments.append(timestamps[100:300])
+#         forceSegments.append(timestamps[350:400])
+#         forceSegments.append(timestamps[550:600])
+#         forceSegments.append(timestamps[700:950])
+#
+#         # Reconcile the segments.
+#         finalSegments = reconcile_markered_and_nonzero_force_segments(timestamps, markerSegments, forceSegments)
+#
+#         # Check that the correct segments were detected.
+#         self.assertEqual(len(finalSegments), 3)
+#         self.assertEqual(finalSegments[0], (1.0, 2.0))
+#         self.assertEqual(finalSegments[1], (5.5, 6.0))
+#         self.assertEqual(finalSegments[2], (8.0, 9.5))
 
 
 class TestRajagopal2015(unittest.TestCase):
@@ -160,17 +161,28 @@ class TestRajagopal2015(unittest.TestCase):
 
         # Run the pipeline.
         # -----------------
-        engine.validate_paths()
-        engine.parse_subject_json()
-        engine.load_model_files()
-        engine.configure_marker_fitter()
-        engine.segment_trials()
-        engine.run_marker_fitting()
-        if engine.fitDynamics:
-            engine.run_dynamics_fitting()
-        engine.write_result_files()
-        engine.generate_readme()
-        engine.create_output_folder()
+        try:
+            engine.validate_paths()
+            engine.parse_subject_json()
+            engine.load_model_files()
+            engine.configure_marker_fitter()
+            engine.preprocess_trials()
+            engine.run_marker_fitting()
+            if engine.fitDynamics:
+                engine.run_dynamics_fitting()
+            engine.write_result_files()
+            engine.generate_readme()
+            engine.create_output_folder()
+
+            # If we succeeded, write an empty JSON file.
+            with open(engine.errors_json_path, "w") as json_file:
+                json_file.write("{}")
+
+        except Error as e:
+            # If we failed, write a JSON file with the error information.
+            json_data = json.dumps(e.get_error_dict(), indent=4)
+            with open(engine.errors_json_path, "w") as json_file:
+                json_file.write(json_data)
 
         # Check the results
         # -----------------

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -22,98 +22,98 @@ DATA_FOLDER_PATH = absPath('../data')
 GEOMETRY_FOLDER_PATH = absPath('Geometry')
 
 
-# class TestTrialSegmentation(unittest.TestCase):
-#     def test_detectNonZeroForceSegments(self):
-#         # Create force plate data with intermittent loads.
-#         timestamps = np.linspace(0, 6.0, 601)
-#         totalLoad = np.zeros(len(timestamps))
-#
-#         # Add a legitimate load segment.
-#         totalLoad[50:100] = 1.0
-#         # Add a load segment that is too short.
-#         totalLoad[250:254] = 1.0
-#         # Add two load segments that should be merged together.
-#         totalLoad[300:340] = 1.0
-#         totalLoad[360:400] = 1.0
-#         # Add a segment that has load up until the final time point.
-#         totalLoad[550:601] = 1.0
-#
-#         # Detect the non-zero force segments.
-#         nonzeroForceSegments = detect_nonzero_force_segments(timestamps, totalLoad)
-#
-#         # Check that the correct segments were detected, before filtering.
-#         self.assertEqual(len(nonzeroForceSegments), 5)
-#         self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
-#         self.assertEqual(nonzeroForceSegments[1][0], 2.5)
-#         self.assertAlmostEqual(nonzeroForceSegments[1][1], 2.54, places=5)
-#         self.assertEqual(nonzeroForceSegments[2], (3.0, 3.4))
-#         self.assertEqual(nonzeroForceSegments[3], (3.6, 4.0))
-#         self.assertEqual(nonzeroForceSegments[4], (5.5, 6.0))
-#
-#         # Now filter the segments.
-#         nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
-#
-#         # Check that the correct segments were detected, after filtering.
-#         self.assertEqual(len(nonzeroForceSegments), 3)
-#         self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
-#         self.assertEqual(nonzeroForceSegments[1], (3.0, 4.0))
-#         self.assertEqual(nonzeroForceSegments[2], (5.5, 6.0))
-#
-#     def test_Camargo2021(self):
-#         # Load the data.
-#         trcFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01.trc'
-#         grfFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01_grf.mot'
-#         trcFile: nimble.biomechanics.OpenSimTRC = nimble.biomechanics.OpenSimParser.loadTRC(trcFilePath)
-#         forcePlates: List[nimble.biomechanics.ForcePlate] = nimble.biomechanics.OpenSimParser.loadGRF(
-#             grfFilePath, trcFile.framesPerSecond)
-#
-#         # Compute the total load.
-#         totalLoad = np.zeros(len(forcePlates[0].timestamps))
-#         for itime in range(len(totalLoad)):
-#             totalForce = 0
-#             totalMoment = 0
-#             for forcePlate in forcePlates:
-#                 totalForce += np.linalg.norm(forcePlate.forces[itime])
-#                 totalMoment += np.linalg.norm(forcePlate.moments[itime])
-#             totalLoad[itime] = totalForce + totalMoment
-#
-#         # Detect the non-zero force segments.
-#         nonzeroForceSegments = detect_nonzero_force_segments(forcePlates[0].timestamps, totalLoad)
-#
-#         # Filter the segments.
-#         nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
-#
-#         # Check that the correct segments were detected.
-#         self.assertEqual(len(nonzeroForceSegments), 3)
-#         self.assertEqual(nonzeroForceSegments[0], (0.005, 5.92))
-#         self.assertEqual(nonzeroForceSegments[1], (7.365, 8.455))
-#         self.assertEqual(nonzeroForceSegments[2], (11.895, 15.335))
-#
-#     def test_reconcileMarkeredAndNonzeroForceSegments(self):
-#         # Create force plate data with intermittent loads.
-#         timestamps = np.linspace(0, 10.0, 1001)
-#
-#         # Create marker segments
-#         markerSegments = list()
-#         markerSegments.append(timestamps[0:200])
-#         markerSegments.append(timestamps[500:600])
-#         markerSegments.append(timestamps[800:1000])
-#
-#         # Create force segments
-#         forceSegments = list()
-#         forceSegments.append(timestamps[100:300])
-#         forceSegments.append(timestamps[350:400])
-#         forceSegments.append(timestamps[550:600])
-#         forceSegments.append(timestamps[700:950])
-#
-#         # Reconcile the segments.
-#         finalSegments = reconcile_markered_and_nonzero_force_segments(timestamps, markerSegments, forceSegments)
-#
-#         # Check that the correct segments were detected.
-#         self.assertEqual(len(finalSegments), 3)
-#         self.assertEqual(finalSegments[0], (1.0, 2.0))
-#         self.assertEqual(finalSegments[1], (5.5, 6.0))
-#         self.assertEqual(finalSegments[2], (8.0, 9.5))
+class TestTrialSegmentation(unittest.TestCase):
+    def test_detectNonZeroForceSegments(self):
+        # Create force plate data with intermittent loads.
+        timestamps = np.linspace(0, 6.0, 601)
+        totalLoad = np.zeros(len(timestamps))
+
+        # Add a legitimate load segment.
+        totalLoad[50:100] = 1.0
+        # Add a load segment that is too short.
+        totalLoad[250:254] = 1.0
+        # Add two load segments that should be merged together.
+        totalLoad[300:340] = 1.0
+        totalLoad[360:400] = 1.0
+        # Add a segment that has load up until the final time point.
+        totalLoad[550:601] = 1.0
+
+        # Detect the non-zero force segments.
+        nonzeroForceSegments = detect_nonzero_force_segments(timestamps, totalLoad)
+
+        # Check that the correct segments were detected, before filtering.
+        self.assertEqual(len(nonzeroForceSegments), 5)
+        self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
+        self.assertEqual(nonzeroForceSegments[1][0], 2.5)
+        self.assertAlmostEqual(nonzeroForceSegments[1][1], 2.54, places=5)
+        self.assertEqual(nonzeroForceSegments[2], (3.0, 3.4))
+        self.assertEqual(nonzeroForceSegments[3], (3.6, 4.0))
+        self.assertEqual(nonzeroForceSegments[4], (5.5, 6.0))
+
+        # Now filter the segments.
+        nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
+
+        # Check that the correct segments were detected, after filtering.
+        self.assertEqual(len(nonzeroForceSegments), 3)
+        self.assertEqual(nonzeroForceSegments[0], (0.5, 1.0))
+        self.assertEqual(nonzeroForceSegments[1], (3.0, 4.0))
+        self.assertEqual(nonzeroForceSegments[2], (5.5, 6.0))
+
+    def test_Camargo2021(self):
+        # Load the data.
+        trcFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01.trc'
+        grfFilePath = DATA_FOLDER_PATH + '/Camargo2021/levelground_ccw_fast_01_01_grf.mot'
+        trcFile: nimble.biomechanics.OpenSimTRC = nimble.biomechanics.OpenSimParser.loadTRC(trcFilePath)
+        forcePlates: List[nimble.biomechanics.ForcePlate] = nimble.biomechanics.OpenSimParser.loadGRF(
+            grfFilePath, trcFile.framesPerSecond)
+
+        # Compute the total load.
+        totalLoad = np.zeros(len(forcePlates[0].timestamps))
+        for itime in range(len(totalLoad)):
+            totalForce = 0
+            totalMoment = 0
+            for forcePlate in forcePlates:
+                totalForce += np.linalg.norm(forcePlate.forces[itime])
+                totalMoment += np.linalg.norm(forcePlate.moments[itime])
+            totalLoad[itime] = totalForce + totalMoment
+
+        # Detect the non-zero force segments.
+        nonzeroForceSegments = detect_nonzero_force_segments(forcePlates[0].timestamps, totalLoad)
+
+        # Filter the segments.
+        nonzeroForceSegments = filter_nonzero_force_segments(nonzeroForceSegments, 0.05, 1.0)
+
+        # Check that the correct segments were detected.
+        self.assertEqual(len(nonzeroForceSegments), 3)
+        self.assertEqual(nonzeroForceSegments[0], (0.005, 5.92))
+        self.assertEqual(nonzeroForceSegments[1], (7.365, 8.455))
+        self.assertEqual(nonzeroForceSegments[2], (11.895, 15.335))
+
+    def test_reconcileMarkeredAndNonzeroForceSegments(self):
+        # Create force plate data with intermittent loads.
+        timestamps = np.linspace(0, 10.0, 1001)
+
+        # Create marker segments
+        markerSegments = list()
+        markerSegments.append(timestamps[0:200])
+        markerSegments.append(timestamps[500:600])
+        markerSegments.append(timestamps[800:1000])
+
+        # Create force segments
+        forceSegments = list()
+        forceSegments.append(timestamps[100:300])
+        forceSegments.append(timestamps[350:400])
+        forceSegments.append(timestamps[550:600])
+        forceSegments.append(timestamps[700:950])
+
+        # Reconcile the segments.
+        finalSegments = reconcile_markered_and_nonzero_force_segments(timestamps, markerSegments, forceSegments)
+
+        # Check that the correct segments were detected.
+        self.assertEqual(len(finalSegments), 3)
+        self.assertEqual(finalSegments[0], (1.0, 2.0))
+        self.assertEqual(finalSegments[1], (5.5, 6.0))
+        self.assertEqual(finalSegments[2], (8.0, 9.5))
 
 
 class TestRajagopal2015(unittest.TestCase):
@@ -194,6 +194,39 @@ class TestRajagopal2015(unittest.TestCase):
         self.assertAlmostEqual(results['autoAvgMax'], 0.043, delta=0.005)
         self.assertAlmostEqual(results['linearResidual'], 3.0, delta=5)
         self.assertAlmostEqual(results['angularResidual'], 1.0, delta=5)
+
+
+class TestErrorReporting(unittest.TestCase):
+    def test_ErrorReportingBasics(self):
+        testing_dir = os.path.join('testing')
+        if not os.path.isdir(testing_dir):
+            os.mkdir(testing_dir)
+        empty_subject_folder = os.path.join(testing_dir, 'empty_subject')
+        if not os.path.isdir(empty_subject_folder):
+            os.mkdir(empty_subject_folder)
+        empty_subject_folder += '/'
+        engine = Engine(path=absPath(empty_subject_folder),
+                        output_name='osim_results',
+                        href='')
+
+        # Run the pipeline.
+        # -----------------
+        try:
+            engine.validate_paths()
+        except Error as e:
+            # If we failed, write a JSON file with the error information.
+            json_data = json.dumps(e.get_error_dict(), indent=4)
+            with open(engine.errors_json_path, "w") as json_file:
+                json_file.write(json_data)
+
+        # Check the results
+        # -----------------
+        errors_fpath = os.path.join(empty_subject_folder, '_errors.json')
+        with open(errors_fpath) as file:
+            errors = json.loads(file.read())
+
+        self.assertTrue(len(errors) == 3)
+        self.assertEqual(errors['type'], 'PathError')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements some basic error reporting features to the framework in `engine.py`:

1. `Engine` is now subclassed to a metaclass `ExceptionHandlingMeta` which automatically wraps all methods of `Engine` with a try-except block (except the `__init__` method).
2. In the except branch, a new exception will be raised that will provide some generic error messaging depending on the stage of the pipeline that the exception occurred in. 
3. This new exception will also pipe through the original error message that can be printed alongside the generic message.
4. All information is printed to a file called `_errors.json`. If no errors occur, an empty `_errors.json` is printed.

A few other things:
- I've added a basic test to `testing.py` that we can expand upon if needed.
- All `exit(1)` calls are now replaced by Python built-in exceptions.
- All calls to the base `Exception` class are replaced by a derived built-in (i.e., at least `RuntimeError`).
