### PR TITLE
Print out `MocoInverse` script for Matlab

### DIFF
--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -1522,9 +1522,14 @@ class Engine(metaclass=ExceptionHandlingMeta):
                 print(f'WARNING: Trial {self.trialNames[itrial]} is too long for Moco! Limiting the time range to '
                       f'[{initial_time}, {final_time}].')
 
-            # 10.4. Fill the template MocoInverse problem for this trial.
+            # 10.4. Fill the template MocoInverse problems for this trial.
             moco_template_fpath = os.path.join(TEMPLATES_PATH, 'template_moco.py')
             moco_inverse_fpath = self.path + f'results/Moco/{self.trialNames[itrial]}_moco.py'
+            fill_moco_template(moco_template_fpath, moco_inverse_fpath, self.trialNames[itrial],
+                               initial_time, final_time)
+
+            moco_template_fpath = os.path.join(TEMPLATES_PATH, 'template_moco.m')
+            moco_inverse_fpath = self.path + f'results/Moco/{self.trialNames[itrial]}_moco.m'
             fill_moco_template(moco_template_fpath, moco_inverse_fpath, self.trialNames[itrial],
                                initial_time, final_time)
 

--- a/server/engine/templates/template_moco.m
+++ b/server/engine/templates/template_moco.m
@@ -57,12 +57,10 @@ table = TimeSeriesTable('../IK/@TRIAL@_ik.mot');
 labels = table.getColumnLabels();
 for i = 0:labels.size()-1
     if strcmp(char(labels.get(i)), 'knee_angle_r')
-        table.appendColumn('knee_angle_r_beta', ...
-            table.getDependentColumn('knee_angle_r'));
+        table.appendColumn('knee_angle_r_beta', table.getDependentColumn('knee_angle_r'));
     end
     if strcmp(char(labels.get(i)), 'knee_angle_l')
-        table.appendColumn('knee_angle_l_beta', ...
-            table.getDependentColumn('knee_angle_l'));
+        table.appendColumn('knee_angle_l_beta', table.getDependentColumn('knee_angle_l'));
     end
 end
 

--- a/server/engine/templates/template_moco.m
+++ b/server/engine/templates/template_moco.m
@@ -1,0 +1,85 @@
+import org.opensim.modeling.*;
+
+% Update the model.
+% -----------------
+% Replace locked coordinates with weld joints.
+model = Model('../Models/final.osim');
+model.initSystem();
+coordinates = model.getCoordinateSet();
+locked_joints = StdVectorString();
+locked_coordinates = {};
+for icoord = 0:coordinates.getSize()-1
+    coord = coordinates.get(icoord);
+    if coord.get_locked()
+        locked_coordinates{end+1} = char(coord.getName());
+        locked_joints.add(coord.getJoint().getName());
+    end
+end
+
+% Remove actuators associated with locked coordinates.
+for i = 1:length(locked_coordinates)
+    coordinate = locked_coordinates{i};
+    forceSet = model.updForceSet();
+    for iforce = 0:forceSet.getSize()-1
+        force = forceSet.get(iforce);
+        actu = CoordinateActuator.safeDownCast(force);
+        if ~isempty(actu) 
+            if strcmp(actu.get_coordinate(), coordinate)
+                forceSet.remove(iforce);
+                break;
+            end
+        end
+    end
+end
+
+model.finalizeConnections();
+model.initSystem();
+
+% Construct a ModelProcessor.
+modelProcessor = ModelProcessor(model);
+modelProcessor.append(ModOpReplaceJointsWithWelds(locked_joints));
+modelProcessor.append(ModOpAddExternalLoads('../ID/@TRIAL@_external_forces.xml'));
+modelProcessor.append(ModOpIgnoreTendonCompliance());
+modelProcessor.append(ModOpReplaceMusclesWithDeGrooteFregly2016());
+modelProcessor.append(ModOpIgnorePassiveFiberForcesDGF());
+modelProcessor.append(ModOpAddReserves(50.0));
+
+% Construct the MocoInverse tool.
+inverse = MocoInverse();
+
+% Set the model processor and time bounds.
+inverse.setModel(modelProcessor);
+inverse.set_initial_time(@INITIAL_TIME@);
+inverse.set_final_time(@FINAL_TIME@);
+
+% Load the kinematics data source.
+table = TimeSeriesTable('../IK/@TRIAL@_ik.mot');
+labels = table.getColumnLabels();
+for i = 0:labels.size()-1
+    if strcmp(char(labels.get(i)), 'knee_angle_r')
+        table.appendColumn('knee_angle_r_beta', ...
+            table.getDependentColumn('knee_angle_r'));
+    end
+    if strcmp(char(labels.get(i)), 'knee_angle_l')
+        table.appendColumn('knee_angle_l_beta', ...
+            table.getDependentColumn('knee_angle_l'));
+    end
+end
+
+% Construct a TableProcessor to update the kinematics table labels.
+tableProcessor = TableProcessor(table);
+tableProcessor.append(TabOpUseAbsoluteStateNames());
+inverse.setKinematics(tableProcessor);
+
+% Configure additional settings for the MocoInverse problem.
+inverse.set_mesh_interval(0.02);
+inverse.set_convergence_tolerance(1e-5);
+inverse.set_constraint_tolerance(1e-5);
+inverse.set_max_iterations(2000);
+inverse.set_kinematics_allow_extra_columns(true);
+
+% Solve the problem.
+% ------------------
+% Solve the problem and write the solution to a Storage file.
+solution = inverse.solve();
+solution.getMocoSolution().write('@TRIAL@_moco.sto');


### PR DESCRIPTION
This PR adds `template_moco.m`, which prints out a `MocoInverse` script to using in Matlab (similar to `template_moco.py`). The necessary changes to `engine.py` are included as well.