### PR TITLE
The harvester now reads the standard skeletons from S3

### DIFF
--- a/server/Dockerfile.harvester_dev
+++ b/server/Dockerfile.harvester_dev
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+FROM keenon/biomechnet_base
+# Tag as keenon/biomechnet_harvester_dev
+
+#########################################################
+# Set up access to AWS (most of this work sets up IOT)
+#########################################################
+
+# Install basic tools
+RUN apt-get update
+RUN apt-get install -y curl unzip jq
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip -o awscliv2.zip && \
+    ./aws/install
+COPY .aws /root/.aws
+# Check that AWS is working
+RUN aws iot describe-endpoint --endpoint-type iot:Data-ATS
+# Generate a unique device name for this Docker container
+RUN echo "$(date '+%s')" > date.txt
+RUN echo "Device$(cat date.txt)" > device_name.txt
+RUN echo "DevicePolicy$(cat date.txt)" > policy_name.txt
+RUN aws iot create-thing --thing-name $(cat device_name.txt)
+# Get/Create the certs
+RUN mkdir /root/certs
+RUN curl -o /root/certs/Amazon-root-CA-1.pem https://www.amazontrust.com/repository/AmazonRootCA1.pem 
+RUN aws iot create-keys-and-certificate \
+    --set-as-active \
+    --certificate-pem-outfile "/root/certs/device.pem.crt" \
+    --public-key-outfile "/root/certs/public.pem.key" \
+    --private-key-outfile "/root/certs/private.pem.key" > cert.json
+RUN echo $(cat cert.json | jq -r '.certificateArn') > certArn.txt
+RUN cat certArn.txt
+RUN aws iot attach-thing-principal \
+    --thing-name "$(cat device_name.txt)" \
+    --principal "$(cat certArn.txt)"
+COPY ./policy.json /root/policy.json
+RUN aws iot create-policy \
+    --policy-name "$(cat policy_name.txt)" \
+    --policy-document "file://root/policy.json"
+RUN aws iot attach-policy \
+    --policy-name "$(cat policy_name.txt)" \
+    --target "$(cat certArn.txt)"
+
+# Preinstall PyTorch, because it's huge and it's good to cache that layer
+
+RUN pip3 install torch
+
+#########################################################
+# Set up the server app
+#########################################################
+
+RUN echo "Installing requirements"
+COPY ./app /app
+COPY ./engine /engine
+COPY ./data /data
+COPY ./server_credentials.csv /server_credentials.csv
+RUN pip3 install -r /app/requirements.txt
+RUN pip3 install -r /engine/requirements.txt
+RUN pip3 install pandas matplotlib
+
+#########################################################
+# Run with dev settings
+#########################################################
+CMD python3 /app/data_harvester.py --bucket biomechanics-uploads161949-dev --deployment DEV

--- a/server/Dockerfile.harvester_prod
+++ b/server/Dockerfile.harvester_prod
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+FROM keenon/biomechnet_base
+# Tag as keenon/biomechnet_harvester_prod
+
+#########################################################
+# Set up access to AWS (most of this work sets up IOT)
+#########################################################
+
+# Install basic tools
+RUN apt-get update
+RUN apt-get install -y curl unzip jq
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip -o awscliv2.zip && \
+    ./aws/install
+COPY .aws /root/.aws
+# Check that AWS is working
+RUN aws iot describe-endpoint --endpoint-type iot:Data-ATS
+# Generate a unique device name for this Docker container
+RUN echo "$(date '+%s')" > date.txt
+RUN echo "Device$(cat date.txt)" > device_name.txt
+RUN echo "DevicePolicy$(cat date.txt)" > policy_name.txt
+RUN aws iot create-thing --thing-name $(cat device_name.txt)
+# Get/Create the certs
+RUN mkdir /root/certs
+RUN curl -o /root/certs/Amazon-root-CA-1.pem https://www.amazontrust.com/repository/AmazonRootCA1.pem 
+RUN aws iot create-keys-and-certificate \
+    --set-as-active \
+    --certificate-pem-outfile "/root/certs/device.pem.crt" \
+    --public-key-outfile "/root/certs/public.pem.key" \
+    --private-key-outfile "/root/certs/private.pem.key" > cert.json
+RUN echo $(cat cert.json | jq -r '.certificateArn') > certArn.txt
+RUN cat certArn.txt
+RUN aws iot attach-thing-principal \
+    --thing-name "$(cat device_name.txt)" \
+    --principal "$(cat certArn.txt)"
+COPY ./policy.json /root/policy.json
+RUN aws iot create-policy \
+    --policy-name "$(cat policy_name.txt)" \
+    --policy-document "file://root/policy.json"
+RUN aws iot attach-policy \
+    --policy-name "$(cat policy_name.txt)" \
+    --target "$(cat certArn.txt)"
+
+# Preinstall PyTorch, because it's huge and it's good to cache that layer
+
+RUN pip3 install torch
+
+#########################################################
+# Set up the server app
+#########################################################
+
+RUN echo "Installing requirements"
+COPY ./app /app
+COPY ./engine /engine
+COPY ./data /data
+COPY ./server_credentials.csv /server_credentials.csv
+RUN pip3 install -r /app/requirements.txt
+RUN pip3 install -r /engine/requirements.txt
+RUN pip3 install pandas matplotlib
+
+#########################################################
+# Run with PROD settings
+#########################################################
+CMD python3 /app/data_harvester.py --bucket biomechanics-uploads83039-prod --deployment PROD

--- a/server/app/data_harvester.py
+++ b/server/app/data_harvester.py
@@ -82,13 +82,22 @@ class SubjectSnapshot:
         contents are complete. Because this process can be killed at any time, there may be a partial upload that was
         cancelled when still incomplete, and if that happens we need to re-translate the data.
         """
-        # Check if the root folder exists
+        # # Check if the root folder exists
         if not self.index.exists(self.get_target_path(dataset)):
             return False
         # Check if all the files exist
         for child in self.index.getChildren(self.path):
-            if not self.index.exists(self.get_target_path(dataset) + child):
-                return False
+            if not self.index.exists(self.get_target_path(dataset) + '/' + child):
+                if child == 'READY_TO_PROCESS' or \
+                    child.endswith('.osim') or \
+                        child.endswith('.mot') or \
+                        child.endswith('.trc') or \
+                        child.endswith('.c3d') or \
+                        child.endswith('_subject.json'):
+                    print('Detected that dataset '+dataset.s3_root_path+' was incompletely uploaded! Missing file ' +
+                          self.get_target_path(dataset) + '/' + child)
+                    return False
+        # If we make it through all these checks
         return True
 
     def copy_snapshots(self, datasets: List[StandardizedDataset]):

--- a/server/app/mocap_server.py
+++ b/server/app/mocap_server.py
@@ -150,6 +150,7 @@ class SubjectToProcess:
 
         # Trial files
         self.readyFlagFile = self.subjectPath + 'READY_TO_PROCESS'
+        self.dynamicsFlagFile = self.subjectPath + 'DYNAMICS'
         self.queuedOnSlurmFlagFile = self.subjectPath + 'SLURM'
         self.processingFlagFile = self.subjectPath + 'PROCESSING'
         self.errorFlagFile = self.subjectPath + 'ERROR'
@@ -366,6 +367,13 @@ class SubjectToProcess:
                 if os.path.exists(path + '_results.json'):
                     self.index.uploadFile(
                         self.resultsFile, path + '_results.json')
+                    # Load the results file, and look for the 'linearResidual' field to indicate that there was dynamics
+                    # in the model. If there was, then we need to upload a DYNAMICS flag to the frontend to make it
+                    # easier to sort datasets by whether they have dynamics or not.
+                    with open(path + '_results.json') as results:
+                        resultsJson = json.loads(results.read())
+                        if 'linearResidual' in resultsJson:
+                            self.index.uploadText(self.dynamicsFlagFile, '')
                 else:
                     print('WARNING! FILE NOT UPLOADED BECAUSE FILE NOT FOUND! ' +
                           path + '_results.json', flush=True)

--- a/server/app/mocap_server.py
+++ b/server/app/mocap_server.py
@@ -572,8 +572,10 @@ class MocapServer:
                     print('- should process: '+str(subject.subjectPath))
                     shouldProcessSubjects.append(subject)
 
-        # 2. Sort Trials oldest to newest, sort by default sorts in ascending order
-        shouldProcessSubjects.sort(key=lambda x: x.latestInputTimestamp())
+        # 2. Sort Trials. First we prioritize subjects that are not just copies in the "standardized" bucket, then
+        # we sort oldest to newest. The sort method gets passed a Tuple, which goes left to right, True before False,
+        # and low to high.
+        shouldProcessSubjects.sort(key=lambda x: (not x.subjectPath.startswith("standardized"), x.latestInputTimestamp()))
 
         # 3. Update the queue. There's another thread that busy-waits on the queue changing, that can then grab a queue entry and continue
         self.queue = shouldProcessSubjects

--- a/server/app/reactive_s3/reactive_s3_index.py
+++ b/server/app/reactive_s3/reactive_s3_index.py
@@ -188,7 +188,7 @@ class ReactiveS3Index:
                         allChildren[key].lastModified, immediateChildren[folderName].lastModified)
                 else:
                     immediateChildren[folderName] = FileMetadata(
-                        key=folderName, lastModified=allChildren[key].lastModified, size=allChildren[key].size)
+                        key=folderName, lastModified=allChildren[key].lastModified, size=allChildren[key].size, eTag=allChildren[key].eTag)
         return immediateChildren
 
     def hasChildren(self, folder: str, subPaths: List[str]) -> bool:

--- a/server/app/reactive_s3/reactive_s3_index.py
+++ b/server/app/reactive_s3/reactive_s3_index.py
@@ -326,7 +326,8 @@ class ReactiveS3Index:
         key: str = body['key']
         lastModified: int = body['lastModified']
         size: int = body['size']
-        file = FileMetadata(key, lastModified, size)
+        eTag: str = body['eTag'] if 'eTag' in body else ''
+        file = FileMetadata(key, lastModified, size, eTag)
         print("onUpdate() file: "+str(file))
         self.files[key] = file
         self.updateChildrenOnAddFile(key)

--- a/server/slurm_persistent_harvester_job_dev.sh
+++ b/server/slurm_persistent_harvester_job_dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --job-name=addbiomechanics_mocapserver_dev
+#SBATCH --job-name=dev_addb_harverser
 #SBATCH --dependency=singleton
 #SBATCH --time=00:60:00
 #SBATCH --signal=B:SIGUSR1@90

--- a/server/slurm_persistent_harvester_job_dev.sh
+++ b/server/slurm_persistent_harvester_job_dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#SBATCH --job-name=addbiomechanics_mocapserver_dev
+#SBATCH --dependency=singleton
+#SBATCH --time=00:60:00
+#SBATCH --signal=B:SIGUSR1@90
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=4000M
+#SBATCH --partition=bioe
+
+# catch the SIGUSR1 signal
+_resubmit() {
+    ## Resubmit the job for the next execution
+    echo "$(date): job $SLURM_JOBID received SIGUSR1 at $(date), re-submitting"
+    sbatch $0
+}
+trap _resubmit SIGUSR1
+
+ml python/3.9.0
+## Run the data harvester, in the background so that we don't lose the trap signal
+CERT_HOME="/home/users/keenon/certs" python3 ~/AddBiomechanics/server/app/data_harvester.py --bucket biomechanics-uploads161949-dev --deployment DEV &
+# Don't exit while the harvester is running
+wait

--- a/server/slurm_persistent_harvester_job_prod.sh
+++ b/server/slurm_persistent_harvester_job_prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --job-name=addbiomechanics_mocapserver_dev
+#SBATCH --job-name=prod_addb_harverser
 #SBATCH --dependency=singleton
 #SBATCH --time=00:60:00
 #SBATCH --signal=B:SIGUSR1@90

--- a/server/slurm_persistent_harvester_job_prod.sh
+++ b/server/slurm_persistent_harvester_job_prod.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#SBATCH --job-name=addbiomechanics_mocapserver_dev
+#SBATCH --dependency=singleton
+#SBATCH --time=00:60:00
+#SBATCH --signal=B:SIGUSR1@90
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=4000M
+#SBATCH --partition=bioe
+
+# catch the SIGUSR1 signal
+_resubmit() {
+    ## Resubmit the job for the next execution
+    echo "$(date): job $SLURM_JOBID received SIGUSR1 at $(date), re-submitting"
+    sbatch $0
+}
+trap _resubmit SIGUSR1
+
+ml python/3.9.0
+## Run the data harvester, in the background so that we don't lose the trap signal
+CERT_HOME="/home/users/keenon/certs" python3 ~/AddBiomechanics/server/app/data_harvester.py --bucket biomechanics-uploads83039-prod --deployment PROD &
+# Don't exit while the harvester is running
+wait

--- a/server/slurm_persistent_job_dev.sh
+++ b/server/slurm_persistent_job_dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --job-name=addbiomechanics_mocapserver_dev
+#SBATCH --job-name=dev_addb_mocapserver
 #SBATCH --dependency=singleton
 #SBATCH --time=00:60:00
 #SBATCH --signal=B:SIGUSR1@90

--- a/server/slurm_persistent_job_prod.sh
+++ b/server/slurm_persistent_job_prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --job-name=addbiomechanics_mocapserver_prod
+#SBATCH --job-name=prod_addb_mocapserver
 #SBATCH --dependency=singleton
 #SBATCH --time=00:60:00
 #SBATCH --signal=B:SIGUSR1@90

--- a/test_harvester.sh
+++ b/test_harvester.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 server/app/data_harvester.py rajagopal_with_arms server/data/StandardizedModels/Rajagopal2015_passiveCal_hipAbdMoved.osim --disable-pubsub True
+python3 server/app/data_harvester.py --disable-pubsub True


### PR DESCRIPTION
... instead of taking them as args.

This PR also:
- Fixes a bug with the PubSub system
- Prioritizes the processing of subjects in the "real data" section of S3, and only when that's all done does it add subjects from the "standardized" section
- adds a `DYNAMICS` tag file to subjects who are processed successfully and have dynamics results, to make it easy to filter subjects without downloading everything.