### PR TITLE
Support data trimming to user-provided time ranges

### DIFF
--- a/server/data/Rajagopal2015/raw/_subject.json
+++ b/server/data/Rajagopal2015/raw/_subject.json
@@ -8,13 +8,16 @@
   "email": "nbianco@stanford.edu",
   "skeletonPreset": "custom",
   "disableDynamics": false,
-  "segmentTrials": false,
+  "segmentTrials": true,
   "footBodyNames": [
     "calcn_r",
     "calcn_l"
   ],
   "shiftGRF": false,
   "maxTrialsToSolveMassOver": 4,
-  "exportMoco": false,
-  "runMoco": false
+  "exportMoco": true,
+  "runMoco": true,
+  "trialRanges": {
+    "walk": [0.45, 2.0]
+  }
 }

--- a/server/data/Rajagopal2015/raw/_subject.json
+++ b/server/data/Rajagopal2015/raw/_subject.json
@@ -8,13 +8,13 @@
   "email": "nbianco@stanford.edu",
   "skeletonPreset": "custom",
   "disableDynamics": false,
-  "segmentTrials": true,
+  "segmentTrials": false,
   "footBodyNames": [
     "calcn_r",
     "calcn_l"
   ],
   "shiftGRF": false,
   "maxTrialsToSolveMassOver": 4,
-  "exportMoco": true,
-  "runMoco": true
+  "exportMoco": false,
+  "runMoco": false
 }

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -529,6 +529,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
                                        f'trial.')
 
                 # Trim the force data.
+                print(f'Trimming trial {trialName} to [{trialStart}, {trialEnd}] s...')
                 for forcePlate in self.trialForcePlates[itrial]:
                     forcePlate.trim(trialStart, trialEnd)
 

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -119,7 +119,8 @@ class Engine(metaclass=ExceptionHandlingMeta):
         self.dynamicsRegularizePoses = 0.01
         self.ignoreFootNotOverForcePlate = False
         self.disableDynamics = False
-        self.segmentTrials = True
+        self.segmentTrials = False
+        self.trialRanges = dict()
         self.minSegmentDuration = 0.05
         self.mergeZeroForceSegmentsThreshold = 1.0
         self.footBodyNames = ['calcn_l', 'calcn_r']
@@ -128,7 +129,6 @@ class Engine(metaclass=ExceptionHandlingMeta):
         self.skippedDynamicsReason = None
         self.runMoco = False
         self.skippedMocoReason = None
-        self.trialRanges = dict()
 
         # 0.3. Shared data structures.
         self.skeleton = None

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -545,7 +545,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
 
             # 6.2.4. Split the trial into individual segments where there is marker data and, if applicable, non-zero
             # forces.
-            if self.segmentTrials and not trialAlreadyTrimmed:
+            if not trialAlreadyTrimmed:
                 print(f'Checking trial "{trialName}" for non-zero segments...')
 
                 # Find the markered segments.

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -194,10 +194,10 @@ class TestRajagopal2015(unittest.TestCase):
         with open(results_fpath) as file:
             results = json.loads(file.read())
 
-        self.assertAlmostEqual(results['autoAvgRMSE'], 0.0195, delta=0.005)
-        self.assertAlmostEqual(results['autoAvgMax'], 0.04, delta=0.005)
-        self.assertAlmostEqual(results['linearResidual'], 8.0, delta=5)
-        self.assertAlmostEqual(results['angularResidual'], 10.5, delta=5)
+        self.assertAlmostEqual(results['autoAvgRMSE'], 0.014, delta=0.01)
+        self.assertAlmostEqual(results['autoAvgMax'], 0.035, delta=0.01)
+        self.assertAlmostEqual(results['linearResidual'], 3, delta=5)
+        self.assertAlmostEqual(results['angularResidual'], 7, delta=5)
 
         # Load the Moco results.
         moco_results_fpath = os.path.join(processed_fpath, 'osim_results', 'Moco', 'walk_moco.sto')

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -14,6 +14,7 @@ from nimblephysics.loader import absPath
 from engine import Engine
 import shutil
 import json
+import opensim as osim
 from helpers import detect_nonzero_force_segments, filter_nonzero_force_segments, \
                     reconcile_markered_and_nonzero_force_segments
 from exceptions import Error, TrialPreprocessingError
@@ -197,6 +198,12 @@ class TestRajagopal2015(unittest.TestCase):
         self.assertAlmostEqual(results['linearResidual'], 8.0, delta=5)
         self.assertAlmostEqual(results['angularResidual'], 10.5, delta=5)
 
+        # Load the Moco results.
+        moco_results_fpath = os.path.join(processed_fpath, 'osim_results', 'Moco', 'walk_moco.sto')
+        moco_results = osim.TimeSeriesTable(moco_results_fpath)
+        time = moco_results.getIndependentColumn()
+        self.assertEqual(time[0], 0.45)
+        self.assertEqual(time[-1], 2.0)
 
 class TestErrorReporting(unittest.TestCase):
     def test_ErrorReportingBasics(self):

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -124,8 +124,9 @@ class TestRajagopal2015(unittest.TestCase):
         # ----------------------------------
         data_fpath = '../data/Rajagopal2015'
         processed_fpath = os.path.join(data_fpath, 'processed')
-        if not os.path.isdir(processed_fpath):
-            os.mkdir(processed_fpath)
+        if os.path.isdir(processed_fpath):
+            shutil.rmtree(processed_fpath)
+        os.mkdir(processed_fpath)
         model_src = os.path.join(data_fpath, 'raw', 'Rajagopal2015_CustomMarkerSet.osim')
         model_dst = os.path.join(data_fpath, 'processed', 'unscaled_generic.osim')
         shutil.copyfile(model_src, model_dst)

--- a/server/engine/testing.py
+++ b/server/engine/testing.py
@@ -192,10 +192,10 @@ class TestRajagopal2015(unittest.TestCase):
         with open(results_fpath) as file:
             results = json.loads(file.read())
 
-        self.assertAlmostEqual(results['autoAvgRMSE'], 0.016, delta=0.002)
+        self.assertAlmostEqual(results['autoAvgRMSE'], 0.0195, delta=0.005)
         self.assertAlmostEqual(results['autoAvgMax'], 0.04, delta=0.005)
-        self.assertAlmostEqual(results['linearResidual'], 5.0, delta=5)
-        self.assertAlmostEqual(results['angularResidual'], 10.0, delta=5)
+        self.assertAlmostEqual(results['linearResidual'], 8.0, delta=5)
+        self.assertAlmostEqual(results['angularResidual'], 10.5, delta=5)
 
 
 class TestErrorReporting(unittest.TestCase):


### PR DESCRIPTION
This PR updates the data trimming logic to support trimming based on user-provided time ranges. The time ranges can be specified for each trial individually by providing a dictionary in `subjectJson` whose keys are the trial names and the values are a two-element arrays specifying the initial and final times. 

We still always check to see if the time range between the markers and ground reaction forces are consistent. If not, we trim the markers and forces to the intersection of both time ranges. The remaining trimming logic, if enabled, comes after that.

We also now issue warnings if the either 1) we had to trim the markers/GRFs to be consistent or 2) if trial trimming/segmentation was not enabled, but probably should be. 