### PR TITLE
Add trial time ranges to `_result.json` files to support frond-end display

### DIFF
--- a/server/data/Rajagopal2015/raw/_subject.json
+++ b/server/data/Rajagopal2015/raw/_subject.json
@@ -8,7 +8,6 @@
   "email": "nbianco@stanford.edu",
   "skeletonPreset": "custom",
   "disableDynamics": false,
-  "segmentTrials": true,
   "footBodyNames": [
     "calcn_r",
     "calcn_l"

--- a/server/data/Rajagopal2015/raw/_subject.json
+++ b/server/data/Rajagopal2015/raw/_subject.json
@@ -8,6 +8,7 @@
   "email": "nbianco@stanford.edu",
   "skeletonPreset": "custom",
   "disableDynamics": false,
+  "segmentedTrials": ["walk"],
   "footBodyNames": [
     "calcn_r",
     "calcn_l"

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -614,6 +614,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
                     baseFramesPerSecond = self.trialFramesPerSecond.pop(itrial)
                     baseMarkerSet = self.trialMarkerSet.pop(trialName)
                     baseMarkerTrial = self.markerTrials.pop(itrial)
+                    baseTrialProcessingResults = self.trialProcessingResults.pop(itrial)
                     segmentTrialNames = []
                     segmentForcePlates = []
                     segmentTimestamps = []
@@ -659,6 +660,9 @@ class Engine(metaclass=ExceptionHandlingMeta):
                                 markerTrial.append(baseMarkerTrial[itime])
                         segmentMarkerTrials.append(markerTrial)
 
+                        # Append the trial processing results for this segment.
+                        self.trialProcessingResults.append(baseTrialProcessingResults)
+
                     # Insert the new segments into the list of trials.
                     self.trialNames[itrial:itrial] = segmentTrialNames
                     self.trialForcePlates[itrial:itrial] = segmentForcePlates
@@ -695,7 +699,15 @@ class Engine(metaclass=ExceptionHandlingMeta):
             # that are actually just segments of the current trial.
             itrial += numSegments
 
-        # 6.3. Check to see if any ground reaction forces are present in the loaded data. If so, we will attempt to
+        # 6.3. Save the time ranges for each trial.
+        timeRanges = dict()
+        for itrial, trialName in enumerate(self.trialNames):
+            timestamps = self.trialTimestamps[itrial]
+            self.trialProcessingResults[itrial]['timeRange'] = [timestamps[0], timestamps[-1]]
+            timeRanges[trialName] = [timestamps[0], timestamps[-1]]
+        self.processingResult['timeRanges'] = timeRanges
+
+        # 6.4. Check to see if any ground reaction forces are present in the loaded data. If so, we will attempt to
         # fit dynamics later on in the pipeline. If not, we will skip dynamics fitting.
         if not self.disableDynamics:
             if len(self.trialForcePlates) == 0:

--- a/server/engine/engine.py
+++ b/server/engine/engine.py
@@ -119,7 +119,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
         self.dynamicsRegularizePoses = 0.01
         self.ignoreFootNotOverForcePlate = False
         self.disableDynamics = False
-        self.segmentTrials = False
+        self.segmentedTrials = []
         self.trialRanges = dict()
         self.minSegmentDuration = 0.05
         self.mergeZeroForceSegmentsThreshold = 1.0
@@ -272,8 +272,8 @@ class Engine(metaclass=ExceptionHandlingMeta):
         if 'disableDynamics' in subjectJson:
             self.disableDynamics = subjectJson['disableDynamics']
 
-        if 'segmentTrials' in subjectJson:
-            self.segmentTrials = subjectJson['segmentTrials']
+        if 'segmentedTrials' in subjectJson:
+            self.segmentedTrials = subjectJson['segmentedTrials']
 
         if 'minSegmentDuration' in subjectJson:
             self.minSegmentDuration = subjectJson['minSegmentDuration']
@@ -570,7 +570,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
                                                                          totalLoad)
                     if len(nonzeroForceSegments) == 0:
                         nonzeroForceSegments = [[self.trialTimestamps[itrial][0], self.trialTimestamps[itrial][-1]]]
-                        if self.segmentTrials:
+                        if trialName in self.segmentedTrials:
                             print(f'WARNING: No non-zero force segments detected for trial '
                                   f'"{self.trialNames[itrial]}". We must now skip dynamics fitting for all trials...')
                             self.disableDynamics = True
@@ -584,7 +584,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
                                                                          self.mergeZeroForceSegmentsThreshold)
                     if len(nonzeroForceSegments) == 0:
                         nonzeroForceSegments = [[self.trialTimestamps[itrial][0], self.trialTimestamps[itrial][-1]]]
-                        if self.segmentTrials:
+                        if trialName in self.segmentedTrials:
                             print(f'WARNING: No non-zero force segments left in trial "{self.trialNames[itrial]}" ' 
                                   f'after filtering out segments shorter than {self.minSegmentDuration} seconds. '
                                   f'We must now skip dynamics fitting for all trials...')
@@ -601,7 +601,7 @@ class Engine(metaclass=ExceptionHandlingMeta):
                 numSegments = len(segments)
 
                 # Segment the trial.
-                if self.segmentTrials:
+                if trialName in self.segmentedTrials:
                     print(f' --> {len(segments)} markered and non-zero force segment(s) found!')
                     if len(segments) > 1:
                         print(f' --> Splitting trial "{trialName}" into {len(segments)} separate trials.')


### PR DESCRIPTION
### Summary of changes
- Added the final time ranges for each trial in all `_result.json` folders.
- The boolean flag `self.segmentTrials` has been updated to `self.segmentedTrials`, which is a list of trial names to be segemented.

Tested locally.