### PR TITLE
Solved password recovery not working.

### DIFF
--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -99,7 +99,7 @@ const ForgetPassword = () => {
             <p>{t("We've sent a code to your email!")}</p>
             <Link
               to={{
-                pathname: "/enter-confirmation-code",
+                pathname: "/reset-password",
                 search: `?${createSearchParams({ email })}`,
               }}
               state={{ from: location.state?.from }}


### PR DESCRIPTION
This should solve the password recovery bug (#217).

The problem was that the link to the confirmation page was not correct.