### PR TITLE
Reconnect automated exception handling and error message system in backend

### DIFF
--- a/server/engine/src/exceptions.py
+++ b/server/engine/src/exceptions.py
@@ -58,6 +58,12 @@ class ModelFileError(Error):
                "you have provided."
 
 
+class LoadingError(Error):
+    """Raised when loading subject or trials files fails."""
+    def get_message(self):
+        return "LoadingError: Error when loading subject or trials files."
+
+
 class TrialPreprocessingError(Error):
     """Raised when an error occurs during the trial segmentation step."""
     def get_message(self):

--- a/server/engine/src/subject.py
+++ b/server/engine/src/subject.py
@@ -3,8 +3,7 @@ from typing import List, Dict, Tuple, Any, Optional
 import json
 import nimblephysics as nimble
 from nimblephysics import absPath
-from exceptions import Error, PathError, SubjectConfigurationError, ModelFileError, LoadingError, \
-                       TrialPreprocessingError, MarkerFitterError, DynamicsFitterError, MocoError, WriteError
+from exceptions import LoadingError, TrialPreprocessingError, MarkerFitterError, DynamicsFitterError, WriteError
 import numpy as np
 import os
 import shutil

--- a/server/engine/src/subject.py
+++ b/server/engine/src/subject.py
@@ -3,6 +3,8 @@ from typing import List, Dict, Tuple, Any, Optional
 import json
 import nimblephysics as nimble
 from nimblephysics import absPath
+from exceptions import Error, PathError, SubjectConfigurationError, ModelFileError, LoadingError, \
+                       TrialPreprocessingError, MarkerFitterError, DynamicsFitterError, MocoError, WriteError
 import numpy as np
 import os
 import shutil
@@ -21,7 +23,43 @@ KINEMATIC_OSIM_NAME = 'match_markers_but_ignore_physics.osim'
 DYNAMICS_OSIM_NAME = 'match_markers_and_physics.osim'
 
 
-class Subject:
+# This metaclass wraps all methods in the Subject class with a try-except block, except for the __init__ method.
+class ExceptionHandlingMeta(type):
+    # Only the methods in this map will be wrapped with a try-except block.
+    EXCEPTION_MAP = {
+        'load_folder': LoadingError,
+        'segment_trials': TrialPreprocessingError,
+        'run_kinematics_fit': MarkerFitterError,
+        'lowpass_filter': TrialPreprocessingError,
+        'run_dynamics_fit': DynamicsFitterError,
+        # 'run_moco': MocoError,
+        'write_opensim_results': WriteError,
+        'write_b3d_file': WriteError,
+        'write_web_results': WriteError,
+    }
+
+    def __new__(cls, name, bases, attrs):
+        for attr_name, attr_value in attrs.items():
+            if attr_name not in cls.EXCEPTION_MAP:
+                continue
+            if callable(attr_value):
+                attrs[attr_name] = cls.wrap_method(attr_value)
+        return super().__new__(cls, name, bases, attrs)
+
+    @staticmethod
+    def wrap_method(method):
+        def wrapper(*args, **kwargs):
+            try:
+                method(*args, **kwargs)
+            except Exception as e:
+                msg = f"Exception caught in {method.__name__}: {e}"
+                exc_type = ExceptionHandlingMeta.EXCEPTION_MAP.get(method.__name__, Exception)
+                raise exc_type(msg)
+
+        return wrapper
+
+
+class Subject(metaclass=ExceptionHandlingMeta):
     def __init__(self):
         # 0. Initialize the engine.
         # -------------------------


### PR DESCRIPTION
Fixes #221 

As the title suggests, this PR reimplements the automated exception handling from the old `Engine` class. Since the new `Subject` class mostly mimics the old `Engine` class, I've moved the exception handling stuff there.

There is one minor change from the original implementation to note. Since some of the methods within `Subject` are essentially helper methods called by other methods, I've added the new `EXCEPTION_MAP`: only the methods in this map are wrapped with the exception handling logic. These methods should only be the "top-level" methods called by `engine.py`. Otherwise, an `Error` will be raised by every helper method in the stack trace and the original exception message from `nimblephysics` will get buried.

As before, the error messages will get stored in a file `_errors.json` which can be used to populate the frontend with helpful feedback to the user.

Tested the change on the files recently sent from Marilyn Keller. The change successfully produces the expected `RuntimeError` added from https://github.com/keenon/nimblephysics/pull/204.