### PR TITLE
Subject citation deprecated

### DIFF
--- a/frontend/src/pages/data/SubjectView.tsx
+++ b/frontend/src/pages/data/SubjectView.tsx
@@ -766,7 +766,7 @@ const SubjectView = observer((props: SubjectViewProps) => {
 //            completedFormElements++;
 //        }
 //    }
-    if (subjectCitation !== null) {
+    if (subjectCitation !== null && subjectCitation !== "") {
         formElements.push(<div key="citation" className="mb-3">
             <label>Desired Citation:</label>
             <textarea
@@ -796,7 +796,10 @@ const SubjectView = observer((props: SubjectViewProps) => {
                     subjectJson.setAttribute("citation", e.target.value);
                 }}>
             </textarea>
-            <div id="citeHelp" className="form-text">We are deprecating citation for individual subjects. Instead, you should add a citation for the full dataset.</div>
+            <div id="citeHelp" className="form-text">We are replacing citations for individual subjects with dataset citations. Please add a citation for the full dataset and remove the subject citations.</div>
+            <button className="btn btn-warning" onClick={async (e) => {
+                subjectJson.setAttribute("citation", "");
+            }}>Remove Citation</button>
           </div>)
     };
 

--- a/frontend/src/pages/data/SubjectView.tsx
+++ b/frontend/src/pages/data/SubjectView.tsx
@@ -703,9 +703,70 @@ const SubjectView = observer((props: SubjectViewProps) => {
         }
     }
     //////////////////////////////////////////////////////////////////
-    // 1.12. Create the entry for citation info
-    totalFormElements++;
-    if (formCompleteSoFar) {
+    // 1.12. Create the entry for citation ifo
+//    totalFormElements++;
+//    if (formCompleteSoFar) {
+//        formElements.push(<div key="citation" className="mb-3">
+//            <label>Desired Citation:</label>
+//            <textarea
+//                id="citation"
+//                value={subjectCitation == null ? "" : subjectCitation}
+//                className={"form-control" + ((subjectCitation == null) ? " border-primary border-2" : "")}
+//                autoFocus={subjectCitation == null || !subjectCitationComplete}
+//                aria-describedby="citeHelp"
+//                onKeyDown={(e) => {
+//                    if (e.key === 'Enter' || e.key === 'Tab') {
+//                        if (subjectCitation == null) {
+//                            subjectJson.setAttribute("citation", "");
+//                        }
+//                        setSubjectCitationComplete(true);
+//                        const input = e.target as HTMLInputElement;
+//                        input.blur();
+//                    }
+//                }}
+//                disabled={props.readonly}
+//                onFocus={() => {
+//                    subjectJson.onFocusAttribute("citation");
+//                }}
+//                onBlur={() => {
+//                    subjectJson.onBlurAttribute("citation");
+//                }}
+//                onChange={(e) => {
+//                    subjectJson.setAttribute("citation", e.target.value);
+//                }}>
+//            </textarea>
+//            <div id="citeHelp" className="form-text">How do you want this data to be cited?</div>
+//        </div>);
+//
+//        if (subjectCitation == null || !subjectCitationComplete) {
+//            if (subjectCitationComplete) {
+//                setSubjectCitationComplete(false);
+//            }
+//            formCompleteSoFar = false;
+//            formElements.push(<div key='citationConfirm'>
+//                <button type="button" className="btn btn-primary" onClick={() => setSubjectCitationComplete(true)}>Confirm Citation</button> (or press Enter or Tab)
+//            </div>);
+//            formElements.push(<div className="alert alert-dark mt-2" role="alert" key="citationExplanation">
+//                <h4 className="alert-heading">What should I put for my citation?</h4>
+//                <p>
+//                    It's fine to leave this blank, if you don't have a preferred citation. If you do, please include it here.
+//                </p>
+//                <p>
+//                    You can include your citation in any format you like, just note that this information is public.
+//                </p>
+//                <h5>IMPORTANT: NEVER INCLUDE PATIENT IDENTIFYING INFORMATION IN YOUR CITATION!</h5>
+//                <p>
+//                    Definitely do not put something like "Keenon Werling's gait data" in the citation field, unless
+//                    your subject has explicitly given informed consent to be identified and has requested that users
+//                    of the data cite them by name.
+//                </p>
+//            </div>);
+//        }
+//        else {
+//            completedFormElements++;
+//        }
+//    }
+    if (subjectCitation !== null) {
         formElements.push(<div key="citation" className="mb-3">
             <label>Desired Citation:</label>
             <textarea
@@ -724,7 +785,7 @@ const SubjectView = observer((props: SubjectViewProps) => {
                         input.blur();
                     }
                 }}
-                disabled={props.readonly}
+                disabled={true}
                 onFocus={() => {
                     subjectJson.onFocusAttribute("citation");
                 }}
@@ -735,38 +796,9 @@ const SubjectView = observer((props: SubjectViewProps) => {
                     subjectJson.setAttribute("citation", e.target.value);
                 }}>
             </textarea>
-            <div id="citeHelp" className="form-text">How do you want this data to be cited?</div>
-        </div>);
-
-        if (subjectCitation == null || !subjectCitationComplete) {
-            if (subjectCitationComplete) {
-                setSubjectCitationComplete(false);
-            }
-            formCompleteSoFar = false;
-            formElements.push(<div key='citationConfirm'>
-                <button type="button" className="btn btn-primary" onClick={() => setSubjectCitationComplete(true)}>Confirm Citation</button> (or press Enter or Tab)
-            </div>);
-            formElements.push(<div className="alert alert-dark mt-2" role="alert" key="citationExplanation">
-                <h4 className="alert-heading">What should I put for my citation?</h4>
-                <p>
-                    It's fine to leave this blank, if you don't have a preferred citation. If you do, please include it here.
-                </p>
-                <p>
-                    You can include your citation in any format you like, just note that this information is public.
-                </p>
-                <h5>IMPORTANT: NEVER INCLUDE PATIENT IDENTIFYING INFORMATION IN YOUR CITATION!</h5>
-                <p>
-                    Definitely do not put something like "Keenon Werling's gait data" in the citation field, unless
-                    your subject has explicitly given informed consent to be identified and has requested that users
-                    of the data cite them by name.
-                </p>
-            </div>);
-        }
-        else {
-            completedFormElements++;
-        }
-    }
-
+            <div id="citeHelp" className="form-text">We are deprecating citation for individual subjects. Instead, you should add a citation for the full dataset.</div>
+          </div>)
+    };
 
     const subjectForm = (
         <Form onSubmit={(e) => {


### PR DESCRIPTION
Solves #279 

 - New subjects do not have citation anymore. It is only at dataset level.
 - Citations inserted in previous versions appear as non-editable, with a message indicating:
   - We are replacing citations for individual subjects with dataset citations. Please add a citation for the full dataset and remove the subject citations.
 - It is possible to remove old deprecated citations with a new button that only appears if the citation is present.