### PR TITLE
Restructured dropProfilePicture function, so it accepts more image formats

### DIFF
--- a/frontend/src/components/DropFile.tsx
+++ b/frontend/src/components/DropFile.tsx
@@ -156,7 +156,10 @@ const DropFile = observer((props: DropFileProps) => {
           onDragLeave={() => {
             setIsDragActive(false);
           }}
-          onClick={handleFileSelect}>
+          onClick={(e) => {
+            //e.preventDefault();
+            handleFileSelect();
+          }}>
         <div className="dz-message needsclick" style={{
           whiteSpace: 'nowrap',
           overflow: 'hidden',


### PR DESCRIPTION
First check if file is an image. Then convert into canvas and finally convert into png, so we always use the same format internally.
Fixed error of file chooser invoked twice when selecting profile picture in chromium-based browsers.