### PR TITLE
Fixing a bug Six ran into where trials would not delete, and empty trials blocked processing

### DIFF
--- a/frontend/src/model/LiveDirectory.ts
+++ b/frontend/src/model/LiveDirectory.ts
@@ -846,6 +846,7 @@ class LiveDirectoryImpl extends LiveDirectory {
     delete(path: string): Promise<void>
     {
         const fullPath = this.normalizePath(path);
+        console.log("Deleting " + fullPath);
         return this.s3.delete(fullPath).then(() => {
             const topic = this.pubsub.makeTopicPubSubSafe("/DELETE/" + fullPath);
             const updatedFile: FileMetadata = {

--- a/frontend/src/model/SubjectViewState.ts
+++ b/frontend/src/model/SubjectViewState.ts
@@ -434,8 +434,9 @@ class SubjectViewState {
         if (path.endsWith('/')) {
             path = path.substring(0, path.length-1);
         }
+        console.log("Deleting: "+path);
         this.uploadedTrialPaths.delete(path);
-        return this.home.dir.delete(path);
+        return this.home.dir.deleteByPrefix(path);
     }
 
     /**
@@ -492,6 +493,19 @@ class SubjectViewState {
             return Promise.reject("Don't support multiple files for a drop");
         }
     };
+
+    canProcess(): boolean {
+        // Check that all the trials have files that exist:
+        for (let trial of this.trials) {
+            if (!trial.c3dFileExists && !trial.trcFileExists) {
+                return false;
+            }
+            if (trial.trcFileExists && !trial.c3dFileExists) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     submitForProcessing(): Promise<void> {
         return this.readyFlagFile.uploadFlag().then(action(() => {

--- a/frontend/src/pages/data/SubjectView.tsx
+++ b/frontend/src/pages/data/SubjectView.tsx
@@ -11,6 +11,7 @@ import LiveFile from "../../model/LiveFile";
 import { parseLinks, showToast } from "../../utils"
 import { toast } from 'react-toastify';
 import { action } from "mobx";
+import { sub } from "date-fns";
 
 
 type SubjectViewProps = {
@@ -918,12 +919,28 @@ const SubjectView = observer((props: SubjectViewProps) => {
                 When you've uploaded all the files you want, click the "Submit for Processing" button below.
             </p>
         </div>;
-        submitButton =
-            <button className="btn btn-lg btn-primary mt-2" disabled={subjectState.trials.length === 0} style={{ width: '100%' }} onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                subjectState.submitForProcessing();
-            }}>Submit for Processing</button>;
+        if (subjectState.canProcess()) {
+            submitButton =
+                <button className="btn btn-lg btn-primary mt-2" style={{ width: '100%' }} onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    subjectState.submitForProcessing();
+                }}>Submit for Processing</button>;
+        }
+        else {
+            submitButton = <div>
+                <div>
+                    <button className="btn btn-lg btn-primary mt-2" disabled style={{ width: '100%' }} onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        alert("Cannot submit for processing: Some trial(s) are missing markers. Please either upload marker data or detele trials.");
+                    }}>Submit for Processing</button>;
+                </div>
+                <div>
+                    <span className="text-danger">Cannot submit for processing: Some trial(s) are missing markers. Please either upload marker data or detele trials.</span>
+                </div>
+            </div>
+        }
     }
 
     const onDrop = (e: DragEvent) => {


### PR DESCRIPTION
This is a few small fixes to the frontend. Trials had a few child files that weren't being deleted when you tried to delete a trial on the web GUI, which was then causing that trial to stick around.

Six tried to process a subject despite not being able to delete a trial that didn't have markers, but that failed to get picked up by the server, which doesn't allow processing when there are missing trial marker data, so I added a frontend check and an explanation to prevent that behavior.