### PR TITLE
Limit the number of threads during path fitting in the Moco pass

### DIFF
--- a/server/engine/src/moco_pass/moco_pass.py
+++ b/server/engine/src/moco_pass/moco_pass.py
@@ -150,6 +150,8 @@ def fit_function_based_paths(model, coordinate_values, results_dir):
     # Fitted path lengths and moment arms must be within 1mm RMSE.
     fitter.setPathLengthTolerance(5e-3)
     fitter.setMomentArmTolerance(5e-3)
+    if os.cpu_count() > 50:
+        fitter.setNumParallelThreads(50)
     fitter.run()
 
     plot_coordinate_samples(results_dir, model.getName())


### PR DESCRIPTION
Fixes #367.

This prevents failures during processing on Sherlock where the available CPU threads exceeds the number of time points in the provided kinematic data.