### PR TITLE
Update "Data Sharing Mission" page

### DIFF
--- a/static/data_sharing_mission.html
+++ b/static/data_sharing_mission.html
@@ -97,32 +97,6 @@
         data
         folders with any publications or other references that users of your data should cite.</p>
 
-      <h2>What If I Want to Test AddBiomechanics Before Sharing Data?</h2>
-      <p>We know that data may not be ready right away for others to view, download, and use, so we provide the
-        following data
-        sharing options:</p>
-      <ul>
-        <li>When you upload your data, it will by default be tagged as an &quot;Unfinalized Draft&quot;. You can share
-          this data by
-          providing colleagues with a link, but it won't appear in the public search results view unless users
-          explicitly
-          check the box to show draft data. &quot;Unfinalized Draft&quot; data may still be included in the large
-          aggregate human motion
-          datasets that we publish from time-to-time, if it is not a duplicate and passes our automated quality checks,
-          though
-          it will be marked as a draft in the <code>DATA_CITATIONS.txt</code> file, so that end users know you have not
-          certified this data
-          as complete.</li>
-        <li>Once you click &quot;Publish&quot; your data will be automatically searchable. </li>
-        <li>By default, data uploaded to AddBiomechanics is not searchable. It is important to
-          note,
-          however, that while AddBiomechanics makes a best effort at security, it <em><strong>is not cleared to store
-              PHI or HIPAA
-              data</strong></em>, so the private folder should be used only to process data that is not subject to these
-          constraints.
-          Users may only upload up to 10 test trials to this private folder. </li>
-      </ul>
-
       <h2>Can I Delete My Data?</h2>
       <p>Please be aware that we retain copies of all processed data, even
         if it is subsequently
@@ -135,8 +109,8 @@
 
       <h2>How Do I Inform Participants of How Their Data Will Be Used?</h2>
       <p>As with all human subjects research, you must ensure your work has been approved by your institution's ethics
-        committee and
-        you have informed participants of how their data will be used.</p>
+        committee and you have informed participants of how their data will be used. In addition, be aware that AddBiomechanics
+        <em><strong>is not cleared to store PHI or HIPAA data</strong></em>.</p>
       <p>You could use language like the following in your consent (IRB) forms to inform participants about how you will
         share their
         data, and give them the option to opt out.</p>
@@ -149,11 +123,7 @@
           with any
           other identifiable information about me.&quot;</li>
         <li>&quot;Biomechanics data are processed using the AddBiomechanics web application and stored in Amazon Web
-          Services (AWS) S3
-          instances. All drafted and published data stored in these instances are publicly accessible to AddBiomechanics
-          users. Data
-          stored in private user folders are not accessible. Public data will be accessible through the web interface
-          and through
+          Services (AWS) S3 instances. All published data stored in these instances will be made available through
           aggregated data distributions hosted on SimTK.org.&quot;</li>
       </ul>
 


### PR DESCRIPTION
Fixes #379.

Updates the "Data Sharing Mission" page to remove language related to mechanisms that no longer exist in AddBiomechanics (e.g., the private folder, "unfinalized drafts", etc).